### PR TITLE
bug: Angular 2 not working with InputOutputStream

### DIFF
--- a/src/Microsoft.AspNetCore.NodeServices/HostingModels/InputOutputStreamNodeInstance.cs
+++ b/src/Microsoft.AspNetCore.NodeServices/HostingModels/InputOutputStreamNodeInstance.cs
@@ -48,7 +48,7 @@ namespace Microsoft.AspNetCore.NodeServices {
         }
 
         protected override void OnOutputDataReceived(string outputData) {
-            if (this._currentInvocationResult != null) {
+            if (this._currentInvocationResult != null  && outputData.Contains("{")) {
                 this._currentInvocationResult.SetResult(outputData);
             } else {
                 base.OnOutputDataReceived(outputData);


### PR DESCRIPTION
Closes #93
We need to ensure that output recieved data is real boot function response, and not just regular console.log from node process.
This is pretty dumb, but it will fix basic behaivior which described in #93.
If anyone have some ideas how it could be improved, any feedback would be GREAT!