### PR TITLE
In order to use this package in traditional .NET setups and NuGet env…

### DIFF
--- a/src/Microsoft.AspNetCore.NodeServices/Configuration.cs
+++ b/src/Microsoft.AspNetCore.NodeServices/Configuration.cs
@@ -1,3 +1,4 @@
+#if DI_CONFIGURATION
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.PlatformAbstractions;
 using Microsoft.AspNetCore.Hosting;
@@ -49,3 +50,4 @@ namespace Microsoft.AspNetCore.NodeServices {
         }
     }
 }
+#endif

--- a/src/Microsoft.AspNetCore.NodeServices/HostingModels/OutOfProcessNodeInstance.cs
+++ b/src/Microsoft.AspNetCore.NodeServices/HostingModels/OutOfProcessNodeInstance.cs
@@ -66,7 +66,7 @@ namespace Microsoft.AspNetCore.NodeServices {
                     }
 
                     var nodePathValue = existingNodePath + Path.Combine(this._projectPath, "node_modules");
-                    #if NET451
+                    #if NET45 || NET451 || NET452 || NET46 || NET461
                     startInfo.EnvironmentVariables.Add("NODE_PATH", nodePathValue);
                     #else
                     startInfo.Environment.Add("NODE_PATH", nodePathValue);

--- a/src/Microsoft.AspNetCore.NodeServices/project.json
+++ b/src/Microsoft.AspNetCore.NodeServices/project.json
@@ -6,23 +6,68 @@
   },
   "authors": [ "Microsoft" ],
   "dependencies": {
-    "Microsoft.NETCore.App": {
-      "version": "1.0.0-rc2-*",
-      "type": "platform"
-    },
-    "Microsoft.AspNetCore.Hosting.Abstractions": "1.0.0-*",
-    "Microsoft.Extensions.Configuration.Json": "1.0.0-*",
-    "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.0-*",
-    "Microsoft.Extensions.PlatformAbstractions": "1.0.0-*",
     "Newtonsoft.Json": "8.0.3"
   },
   "frameworks": {
     "netcoreapp1.0": {
+      "dependencies": {
+        "Microsoft.NETCore.App": {
+          "version": "1.0.0-rc2-*",
+          "type": "platform"
+        },
+        "Microsoft.AspNetCore.Hosting.Abstractions": "1.0.0-*",
+        "Microsoft.Extensions.Configuration.Json": "1.0.0-*",
+        "Microsoft.Extensions.DependencyInjection.Abstractions": "1.0.0-*",
+        "Microsoft.Extensions.PlatformAbstractions": "1.0.0-*"
+      },
       "imports": [
         "dotnet5.6",
         "dnxcore50",
         "portable-net45+win8"
-      ]
+      ],
+      "buildOptions": {
+        "define": [ "NETCORE", "DI_CONFIGURATION" ]
+      }
+    },
+    "net45": {
+      "dependencies": {
+        "System.Net.Http": "4.0.0"
+      },
+      "buildOptions": {
+        "define": [ "NET45" ]
+      }
+    },
+    "net451": {
+      "dependencies": {
+        "System.Net.Http": "4.0.0"
+      },
+      "buildOptions": {
+        "define": [ "NET451" ]
+      }
+    },
+    "net452": {
+      "dependencies": {
+        "System.Net.Http": "4.0.0"
+      },
+      "buildOptions": {
+        "define": [ "NET452" ]
+      }
+    },
+    "net46": {
+      "dependencies": {
+        "System.Net.Http": "4.0.0"
+      },
+      "buildOptions": {
+        "define": [ "NET46" ]
+      }
+    },
+    "net461": {
+      "dependencies": {
+        "System.Net.Http": "4.0.0"
+      },
+      "buildOptions": {
+        "define": [ "NET461" ]
+      }
     }
   },
   "buildOptions": {


### PR DESCRIPTION
…ironments, there needs to be specific environments created for each version of .NET.

I'm not seeing another way to do this. I may be wrong.