### PR TITLE
feat(prerender): ability to push payload and model to boot func

### DIFF
--- a/src/Microsoft.AspNetCore.NodeServices/INodeInstance.cs
+++ b/src/Microsoft.AspNetCore.NodeServices/INodeInstance.cs
@@ -6,7 +6,7 @@ namespace Microsoft.AspNetCore.NodeServices
     public interface INodeServices : IDisposable
     {
         Task<T> Invoke<T>(string moduleName, params object[] args);
-
+        Task<T> Invoke<T>(NodeInvocationInfo nodeInvocationInfo);
         Task<T> InvokeExport<T>(string moduleName, string exportedFunctionName, params object[] args);
     }
 }

--- a/src/Microsoft.AspNetCore.SpaServices/Configuration.cs
+++ b/src/Microsoft.AspNetCore.SpaServices/Configuration.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.AspNetCore.SpaServices.Prerendering;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+
+namespace Microsoft.AspNetCore.SpaServices
+{
+    public static class Configuration
+    {
+        public static void AddPrerender(this IServiceCollection serviceCollection) => AddPrerender(serviceCollection, _ => new PrerenderOptions());
+
+        public static void AddPrerender(this IServiceCollection services, Func<IServiceProvider, PrerenderOptions> optionsFactory)
+        {
+            services.AddTransient(typeof(PrerenderOptions), optionsFactory);
+            services.AddSingleton(typeof(IPrerenderer), serviceProvider => new Prerenderer(serviceProvider));
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.SpaServices/PrerenderOptions.cs
+++ b/src/Microsoft.AspNetCore.SpaServices/PrerenderOptions.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using Microsoft.AspNetCore.Http;
+
+namespace Microsoft.AspNetCore.SpaServices.Prerendering
+{
+    public class PrerenderOptions
+    {
+        public Func<HttpContext, object[]> PayloadProvider { get; set; } = context => new object[0];
+        public string FileName { get; set; }
+        public string ExportedFunctionName { get; set; } = "renderToString";
+    }
+}

--- a/src/Microsoft.AspNetCore.SpaServices/Prerendering/IPrerenderer.cs
+++ b/src/Microsoft.AspNetCore.SpaServices/Prerendering/IPrerenderer.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.AspNetCore.Http;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.SpaServices.Prerendering
+{
+    public interface IPrerenderer
+    {
+        Task<RenderToStringResult> RenderToString(HttpContext context, JavaScriptModuleExport module, object model = null);
+        Task<RenderToStringResult> RenderToString(string basePath, HttpContext context, JavaScriptModuleExport module, object model = null);
+    }
+}

--- a/src/Microsoft.AspNetCore.SpaServices/Prerendering/Prerenderer.cs
+++ b/src/Microsoft.AspNetCore.SpaServices/Prerendering/Prerenderer.cs
@@ -1,36 +1,54 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.NodeServices;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http.Extensions;
 
 namespace Microsoft.AspNetCore.SpaServices.Prerendering
 {
-    public static class Prerenderer
+    public class Prerenderer : IPrerenderer
     {
-        private static readonly Lazy<StringAsTempFile> NodeScript;
-
-        static Prerenderer()
+        private static Lazy<StringAsTempFile> _nodeScript = new Lazy<StringAsTempFile>(() =>
         {
-            NodeScript = new Lazy<StringAsTempFile>(() =>
+            var script = EmbeddedResourceReader.Read(typeof(Prerenderer), "/Content/Node/prerenderer.js");
+            return new StringAsTempFile(script);
+        });
+
+        private readonly string _applicationBasePath;
+        private readonly INodeServices _nodeServices;
+        private readonly PrerenderOptions _options;
+
+        public Prerenderer(IServiceProvider serviceProvider)
+        {
+            _applicationBasePath = ((IHostingEnvironment)serviceProvider.GetService(typeof(IHostingEnvironment))).ContentRootPath;
+            this._options = (PrerenderOptions)serviceProvider.GetService(typeof(PrerenderOptions)) ?? new PrerenderOptions();
+            this._options.FileName = this._options.FileName ?? _nodeScript.Value.FileName;
+            this._nodeServices = (INodeServices)serviceProvider.GetService(typeof(INodeServices)) ?? NodeServices.Configuration.CreateNodeServices(new NodeServicesOptions
             {
-                var script = EmbeddedResourceReader.Read(typeof(Prerenderer), "/Content/Node/prerenderer.js");
-                return new StringAsTempFile(script); // Will be cleaned up on process exit
+                HostingModel = NodeHostingModel.Http,
+                ProjectPath = _applicationBasePath
             });
         }
 
-        public static Task<RenderToStringResult> RenderToString(
-            string applicationBasePath,
-            INodeServices nodeServices,
-            JavaScriptModuleExport bootModule,
-            string requestAbsoluteUrl,
-            string requestPathAndQuery)
-        {
-            return nodeServices.InvokeExport<RenderToStringResult>(
-                NodeScript.Value.FileName,
-                "renderToString",
-                applicationBasePath,
-                bootModule,
-                requestAbsoluteUrl,
-                requestPathAndQuery);
-        }
+        public Task<RenderToStringResult> RenderToString(HttpContext context, JavaScriptModuleExport module, object model = null)
+            => RenderToString(_applicationBasePath, context, module, model);
+
+        public Task<RenderToStringResult> RenderToString(string basePath, HttpContext context, JavaScriptModuleExport module, object model = null)
+            => _nodeServices.Invoke<RenderToStringResult>(new NodeInvocationInfo
+            {
+                ExportedFunctionName = _options.ExportedFunctionName,
+                ModuleName = _options.FileName,
+                Args = new object[]
+                {
+                    basePath,
+                    module,
+                    UriHelper.GetEncodedUrl(context.Request),
+                    context.Request.Path + context.Request.QueryString.Value,
+                    context.Request.Cookies,
+                    _options.PayloadProvider(context),
+                    model
+                }
+            });
     }
 }

--- a/src/Microsoft.AspNetCore.SpaServices/npm/aspnet-prerendering/src/Prerendering.ts
+++ b/src/Microsoft.AspNetCore.SpaServices/npm/aspnet-prerendering/src/Prerendering.ts
@@ -6,146 +6,155 @@ import { run as domainTaskRun } from 'domain-task/main';
 import { baseUrl } from 'domain-task/fetch';
 
 export interface RenderToStringCallback {
-    (error: any, result: RenderToStringResult): void;
+  (error: any, result: RenderToStringResult): void;
 }
 
 export interface RenderToStringResult {
-    html: string;
-    globals: { [key: string]: any };
+  html: string;
+  globals: { [key: string]: any };
 }
 
 export interface BootFunc {
-    (params: BootFuncParams): Promise<RenderToStringResult>;
+  (params: BootFuncParams, model: any): Promise<RenderToStringResult>;
 }
 
 export interface BootFuncParams {
-    location: url.Url;          // e.g., Location object containing information '/some/path'
-    origin: string;             // e.g., 'https://example.com:1234'
-    url: string;                // e.g., '/some/path'
-    absoluteUrl: string;        // e.g., 'https://example.com:1234/some/path'
-    domainTasks: Promise<any>;
+  location: url.Url;          // e.g., Location object containing information '/some/path'
+  origin: string;             // e.g., 'https://example.com:1234'
+  url: string;                // e.g., '/some/path'
+  absoluteUrl: string;        // e.g., 'https://example.com:1234/some/path'
+  domainTasks: Promise<any>;
+  cookies: Cookie[];
+  payload: any;
+}
+
+export interface Cookie {
+  key: string;
+  value: string;
 }
 
 export interface BootModuleInfo {
-    moduleName: string;
-    exportName?: string;
-    webpackConfig?: string;
+  moduleName: string;
+  exportName?: string;
+  webpackConfig?: string;
 }
 
-export function renderToString(callback: RenderToStringCallback, applicationBasePath: string, bootModule: BootModuleInfo, absoluteRequestUrl: string, requestPathAndQuery: string) {
-    findBootFunc(applicationBasePath, bootModule, (findBootFuncError, bootFunc) => {
-        if (findBootFuncError) {
-            callback(findBootFuncError, null);
-            return;
-        }
+export function renderToString(callback: RenderToStringCallback, applicationBasePath: string, bootModule: BootModuleInfo, absoluteRequestUrl: string, requestPathAndQuery: string, cookies: Cookie[], payload: any, model: any) {
+  findBootFunc(applicationBasePath, bootModule, (findBootFuncError, bootFunc) => {
+    if (findBootFuncError) {
+      callback(findBootFuncError, null);
+      return;
+    }
 
-        // Prepare a promise that will represent the completion of all domain tasks in this execution context.
-        // The boot code will wait for this before performing its final render.
-        let domainTaskCompletionPromiseResolve;
-        const domainTaskCompletionPromise = new Promise((resolve, reject) => {
-            domainTaskCompletionPromiseResolve = resolve;
-        });
-        const parsedAbsoluteRequestUrl = url.parse(absoluteRequestUrl);
-        const params: BootFuncParams = {
-            location: url.parse(requestPathAndQuery),
-            origin: parsedAbsoluteRequestUrl.protocol + '//' + parsedAbsoluteRequestUrl.host,
-            url: requestPathAndQuery,
-            absoluteUrl: absoluteRequestUrl,
-            domainTasks: domainTaskCompletionPromise
-        };
-
-        // Open a new domain that can track all the async tasks involved in the app's execution
-        domainTaskRun(/* code to run */ () => {
-            // Workaround for Node bug where native Promise continuations lose their domain context
-            // (https://github.com/nodejs/node-v0.x-archive/issues/8648)
-            // The domain.active property is set by the domain-context module
-            bindPromiseContinuationsToDomain(domainTaskCompletionPromise, domain['active']);
-
-            // Make the base URL available to the 'domain-tasks/fetch' helper within this execution context
-            baseUrl(absoluteRequestUrl);
-
-            // Actually perform the rendering
-            bootFunc(params).then(successResult => {
-                callback(null, { html: successResult.html, globals: successResult.globals });
-            }, error => {
-                callback(error, null);
-            });
-        }, /* completion callback */ errorOrNothing => {
-            if (errorOrNothing) {
-                callback(errorOrNothing, null);
-            } else {
-                // There are no more ongoing domain tasks (typically data access operations), so we can resolve
-                // the domain tasks promise which notifies the boot code that it can do its final render.
-                domainTaskCompletionPromiseResolve();
-            }
-        });
+    // Prepare a promise that will represent the completion of all domain tasks in this execution context.
+    // The boot code will wait for this before performing its final render.
+    let domainTaskCompletionPromiseResolve;
+    const domainTaskCompletionPromise = new Promise((resolve, reject) => {
+      domainTaskCompletionPromiseResolve = resolve;
     });
+    const parsedAbsoluteRequestUrl = url.parse(absoluteRequestUrl);
+    const params: BootFuncParams = {
+      location: url.parse(requestPathAndQuery),
+      origin: parsedAbsoluteRequestUrl.protocol + '//' + parsedAbsoluteRequestUrl.host,
+      url: requestPathAndQuery,
+      absoluteUrl: absoluteRequestUrl,
+      domainTasks: domainTaskCompletionPromise,
+      cookies: cookies,
+      payload: payload
+    };
+
+    // Open a new domain that can track all the async tasks involved in the app's execution
+    domainTaskRun(/* code to run */() => {
+      // Workaround for Node bug where native Promise continuations lose their domain context
+      // (https://github.com/nodejs/node-v0.x-archive/issues/8648)
+      // The domain.active property is set by the domain-context module
+      bindPromiseContinuationsToDomain(domainTaskCompletionPromise, domain['active']);
+
+      // Make the base URL available to the 'domain-tasks/fetch' helper within this execution context
+      baseUrl(absoluteRequestUrl);
+
+      // Actually perform the rendering
+      bootFunc(params, model).then(successResult => {
+        callback(null, { html: successResult.html, globals: successResult.globals });
+      }, error => {
+        callback(error, null);
+      });
+    }, /* completion callback */ errorOrNothing => {
+      if (errorOrNothing) {
+        callback(errorOrNothing, null);
+      } else {
+        // There are no more ongoing domain tasks (typically data access operations), so we can resolve
+        // the domain tasks promise which notifies the boot code that it can do its final render.
+        domainTaskCompletionPromiseResolve();
+      }
+    });
+  });
 }
 
 function findBootModule<T>(applicationBasePath: string, bootModule: BootModuleInfo, callback: (error: any, foundModule: T) => void) {
-    const bootModuleNameFullPath = path.resolve(applicationBasePath, bootModule.moduleName);
-    if (bootModule.webpackConfig) {
-        const webpackConfigFullPath = path.resolve(applicationBasePath, bootModule.webpackConfig);
-        
-        let aspNetWebpackModule: any;
-        try {
-            aspNetWebpackModule = require('aspnet-webpack');
-        } catch (ex) {
-            callback('To load your boot module via webpack (i.e., if you specify a \'webpackConfig\' option), you must install the \'aspnet-webpack\' NPM package.', null);
-            return;
-        }
+  const bootModuleNameFullPath = path.resolve(applicationBasePath, bootModule.moduleName);
+  if (bootModule.webpackConfig) {
+    const webpackConfigFullPath = path.resolve(applicationBasePath, bootModule.webpackConfig);
 
-        aspNetWebpackModule.loadViaWebpack(webpackConfigFullPath, bootModuleNameFullPath, callback);
-    } else {
-        callback(null, require(bootModuleNameFullPath));
+    let aspNetWebpackModule: any;
+    try {
+      aspNetWebpackModule = require('aspnet-webpack');
+    } catch (ex) {
+      callback('To load your boot module via webpack (i.e., if you specify a \'webpackConfig\' option), you must install the \'aspnet-webpack\' NPM package.', null);
+      return;
     }
+
+    aspNetWebpackModule.loadViaWebpack(webpackConfigFullPath, bootModuleNameFullPath, callback);
+  } else {
+    callback(null, require(bootModuleNameFullPath));
+  }
 }
 
 function findBootFunc(applicationBasePath: string, bootModule: BootModuleInfo, callback: (error: any, bootFunc: BootFunc) => void) {
-    // First try to load the module (possibly via Webpack)
-    findBootModule<any>(applicationBasePath, bootModule, (findBootModuleError, foundBootModule) => {
-        if (findBootModuleError) {
-            callback(findBootModuleError, null);
-            return;
-        }
+  // First try to load the module (possibly via Webpack)
+  findBootModule<any>(applicationBasePath, bootModule, (findBootModuleError, foundBootModule) => {
+    if (findBootModuleError) {
+      callback(findBootModuleError, null);
+      return;
+    }
 
-        // Now try to pick out the function they want us to invoke
-        let bootFunc: BootFunc;
-        if (bootModule.exportName) {
-            // Explicitly-named export
-            bootFunc = foundBootModule[bootModule.exportName];
-        } else if (typeof foundBootModule !== 'function') {
-            // TypeScript-style default export
-            bootFunc = foundBootModule.default;
-        } else {
-            // Native default export
-            bootFunc = foundBootModule;
-        }
+    // Now try to pick out the function they want us to invoke
+    let bootFunc: BootFunc;
+    if (bootModule.exportName) {
+      // Explicitly-named export
+      bootFunc = foundBootModule[bootModule.exportName];
+    } else if (typeof foundBootModule !== 'function') {
+      // TypeScript-style default export
+      bootFunc = foundBootModule.default;
+    } else {
+      // Native default export
+      bootFunc = foundBootModule;
+    }
 
-        // Validate the result
-        if (typeof bootFunc !== 'function') {
-            if (bootModule.exportName) {
-                callback(`The module at ${ bootModule.moduleName } has no function export named ${ bootModule.exportName }.`, null);
-            } else {
-                callback(`The module at ${ bootModule.moduleName } does not export a default function, and you have not specified which export to invoke.`, null);
-            }
-        } else {
-            callback(null, bootFunc);
-        }
-    });
+    // Validate the result
+    if (typeof bootFunc !== 'function') {
+      if (bootModule.exportName) {
+        callback(`The module at ${ bootModule.moduleName } has no function export named ${ bootModule.exportName }.`, null);
+      } else {
+        callback(`The module at ${ bootModule.moduleName } does not export a default function, and you have not specified which export to invoke.`, null);
+      }
+    } else {
+      callback(null, bootFunc);
+    }
+  });
 }
 
 function bindPromiseContinuationsToDomain(promise: Promise<any>, domainInstance: domain.Domain) {
-    const originalThen = promise.then;
-    promise.then = function then(resolve, reject) {
-        if (typeof resolve === 'function') {
-            resolve = domainInstance.bind(resolve);
-        }
+  const originalThen = promise.then;
+  promise.then = function then(resolve, reject) {
+    if (typeof resolve === 'function') {
+      resolve = domainInstance.bind(resolve);
+    }
 
-        if (typeof reject === 'function') {
-            reject = domainInstance.bind(reject);
-        }
+    if (typeof reject === 'function') {
+      reject = domainInstance.bind(reject);
+    }
 
-        return originalThen.call(this, resolve, reject);
-    };
+    return originalThen.call(this, resolve, reject);
+  };
 }


### PR DESCRIPTION
- closes #68 by adding payload provider
- closes #66 by pushing context cookies to boot func
- closes #107 by adding asp-prerender-model attribute

Implemented API:

**Payload provider**
Right now there is an ability to implement some common `PayloadProvider` which could add some neccesary information to every prerender func call. To implement such provider you could use following API:
```
services.AddPrerender(provider => new PrerenderOptions
            {
                PayloadProvider = context => new[] { new { Food = "Borsch", Drink = "Vodka" } },
            });
```
`provider` is just regular `IServiceProvider` with all registred services.
`context` is just a regular `HttpContext` with all required info for your request.
After specifying these `PayloadProvider` you could access this array of object via params object:
```
import * as aspnet from 'aspnet-prerendering';
let boot: aspnet.BootFunc = function (params, model) {
  console.log(params.payload);
};
```

 **Accessing model**
To access model you could add following code to your `View.cshtml`
```
<app asp-prerender-module="ClientApp/boot-server"
     asp-prerender-model="Model"
     asp-prerender-webpack-config="webpack.config.js">Loading...</app>
```
And then access to passed model:
```
import * as aspnet from 'aspnet-prerendering';
let boot: aspnet.BootFunc = function (params, model) {
  console.log(model);
};
```

 **Cookies**
Now it possible to catch aspnet request cookies at server prerender. You may perform these with following code:
```
import * as aspnet from 'aspnet-prerendering';
let boot: aspnet.BootFunc = function (params, model) {
   console.log(params.cookies);
};
```

cc @SteveSandersonMS 

Any feedback would be great for these one.


