### PR TITLE
chore(package): ignore node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ project.lock.json
 .vs/
 npm-debug.log
 /.build/
+node_modules


### PR DESCRIPTION
Currently all node_modules will attempt to be checked in, missing `node_modules` from gitignore file.