### PR TITLE
Makes it possible to use absolute paths for publicPath in weback.config

### DIFF
--- a/src/Microsoft.AspNetCore.SpaServices/npm/aspnet-webpack/src/WebpackDevMiddleware.ts
+++ b/src/Microsoft.AspNetCore.SpaServices/npm/aspnet-webpack/src/WebpackDevMiddleware.ts
@@ -1,5 +1,6 @@
 import * as connect from 'connect';
 import * as webpack from 'webpack';
+import * as url from 'url'
 import { requireNewCopy } from './RequireNewCopy';
 
 export interface CreateDevServerCallback {
@@ -84,7 +85,7 @@ export function createWebpackDevServer(callback: CreateDevServerCallback, option
         // Tell the ASP.NET app what addresses we're listening on, so that it can proxy requests here
         callback(null, {
             Port: listener.address().port,
-            PublicPath: removeTrailingSlash(publicPath)
+            PublicPath: removeTrailingSlash(getPath(publicPath))
         });
     });
 }
@@ -95,4 +96,8 @@ function removeTrailingSlash(str: string) {
     }
 
     return str;
+}
+
+function getPath(publicPath: string){
+    return url.parse(publicPath).path;     
 }


### PR DESCRIPTION
- Parses publicPath as an URL and returns the path of that URL to be able to cope with absolute URLs