### PR TITLE
Added OnBeforeStartExternalProcess callback 

### DIFF
--- a/src/Microsoft.AspNetCore.NodeServices/Configuration/NodeServicesOptions.cs
+++ b/src/Microsoft.AspNetCore.NodeServices/Configuration/NodeServicesOptions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.AspNetCore.NodeServices
             HostingModel = DefaultNodeHostingModel;
             WatchFileExtensions = (string[])DefaultWatchFileExtensions.Clone();
         }
-
+        public Action<System.Diagnostics.ProcessStartInfo> OnBeforeStartExternalProcess { get; set; }
         public NodeHostingModel HostingModel { get; set; }
         public Func<INodeInstance> NodeInstanceFactory { get; set; }
         public string ProjectPath { get; set; }

--- a/src/Microsoft.AspNetCore.NodeServices/HostingModels/HttpNodeInstance.cs
+++ b/src/Microsoft.AspNetCore.NodeServices/HostingModels/HttpNodeInstance.cs
@@ -28,21 +28,22 @@ namespace Microsoft.AspNetCore.NodeServices.HostingModels
             ContractResolver = new CamelCasePropertyNamesContractResolver()
         };
 
-	    private readonly HttpClient _client;
+        private readonly HttpClient _client;
         private bool _disposed;
         private int _portNumber;
 
-        public HttpNodeInstance(string projectPath, string[] watchFileExtensions, int port = 0)
+        public HttpNodeInstance(string projectPath, string[] watchFileExtensions, int port = 0, Action<System.Diagnostics.ProcessStartInfo> onBeforeStartExternalProcess = null)
             : base(
                 EmbeddedResourceReader.Read(
                     typeof(HttpNodeInstance),
                     "/Content/Node/entrypoint-http.js"),
                 projectPath,
                 watchFileExtensions,
-                MakeCommandLineOptions(port))
+                MakeCommandLineOptions(port),
+                onBeforeStartExternalProcess)
         {
             _client = new HttpClient();
-		}
+        }
 
         private static string MakeCommandLineOptions(int port)
         {
@@ -112,18 +113,19 @@ namespace Microsoft.AspNetCore.NodeServices.HostingModels
             }
         }
 
-	    protected override void Dispose(bool disposing) {
-	        base.Dispose(disposing);
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
 
-	        if (!_disposed)
+            if (!_disposed)
             {
-	            if (disposing)
+                if (disposing)
                 {
-	                _client.Dispose();
-	            }
+                    _client.Dispose();
+                }
 
-	            _disposed = true;
-	        }
-	    }
-	}
+                _disposed = true;
+            }
+        }
+    }
 }

--- a/src/Microsoft.AspNetCore.NodeServices/HostingModels/OutOfProcessNodeInstance.cs
+++ b/src/Microsoft.AspNetCore.NodeServices/HostingModels/OutOfProcessNodeInstance.cs
@@ -31,10 +31,11 @@ namespace Microsoft.AspNetCore.NodeServices.HostingModels
             string entryPointScript,
             string projectPath,
             string[] watchFileExtensions,
-            string commandLineArguments)
+            string commandLineArguments,
+             Action<System.Diagnostics.ProcessStartInfo> onBeforeStartExternalProcess = null)
         {
             _entryPointScript = new StringAsTempFile(entryPointScript);
-            _nodeProcess = LaunchNodeProcess(_entryPointScript.FileName, projectPath, commandLineArguments);
+            _nodeProcess = LaunchNodeProcess(_entryPointScript.FileName, projectPath, commandLineArguments, onBeforeStartExternalProcess);
             _watchFileExtensions = watchFileExtensions;
             _fileSystemWatcher = BeginFileWatcher(projectPath);
             ConnectToInputOutputStreams();
@@ -111,7 +112,7 @@ namespace Microsoft.AspNetCore.NodeServices.HostingModels
             }
         }
 
-        private static Process LaunchNodeProcess(string entryPointFilename, string projectPath, string commandLineArguments)
+        private static Process LaunchNodeProcess(string entryPointFilename, string projectPath, string commandLineArguments, Action<System.Diagnostics.ProcessStartInfo> onBeforeStartExternalProcess)
         {
             var startInfo = new ProcessStartInfo("node")
             {
@@ -136,6 +137,10 @@ namespace Microsoft.AspNetCore.NodeServices.HostingModels
 #else
             startInfo.Environment["NODE_PATH"] = nodePathValue;
 #endif
+            if (onBeforeStartExternalProcess != null)
+            {
+                onBeforeStartExternalProcess(startInfo);
+            }
 
             var process = Process.Start(startInfo);
 

--- a/src/Microsoft.AspNetCore.NodeServices/HostingModels/SocketNodeInstance.cs
+++ b/src/Microsoft.AspNetCore.NodeServices/HostingModels/SocketNodeInstance.cs
@@ -25,7 +25,7 @@ namespace Microsoft.AspNetCore.NodeServices.HostingModels
     /// <seealso cref="Microsoft.AspNetCore.NodeServices.HostingModels.OutOfProcessNodeInstance" />
     internal class SocketNodeInstance : OutOfProcessNodeInstance
     {
-        private readonly static JsonSerializerSettings jsonSerializerSettings =  new JsonSerializerSettings
+        private readonly static JsonSerializerSettings jsonSerializerSettings = new JsonSerializerSettings
         {
             ContractResolver = new CamelCasePropertyNamesContractResolver()
         };
@@ -36,16 +36,17 @@ namespace Microsoft.AspNetCore.NodeServices.HostingModels
         private string _socketAddress;
         private VirtualConnectionClient _virtualConnectionClient;
 
-        public SocketNodeInstance(string projectPath, string[] watchFileExtensions, string socketAddress): base(
+        public SocketNodeInstance(string projectPath, string[] watchFileExtensions, string socketAddress, Action<System.Diagnostics.ProcessStartInfo> onBeforeStartExternalProcess = null) : base(
                 EmbeddedResourceReader.Read(
                     typeof(SocketNodeInstance),
                     "/Content/Node/entrypoint-socket.js"),
                 projectPath,
                 watchFileExtensions,
-                MakeNewCommandLineOptions(socketAddress))
+                MakeNewCommandLineOptions(socketAddress),
+                onBeforeStartExternalProcess)
         {
             _socketAddress = socketAddress;
-		}
+        }
 
         protected override async Task<T> InvokeExportAsync<T>(NodeInvocationInfo invocationInfo)
         {
@@ -170,7 +171,7 @@ namespace Microsoft.AspNetCore.NodeServices.HostingModels
 
         private static async Task<byte[]> ReadAllBytesAsync(Stream input)
         {
-            byte[] buffer = new byte[16*1024];
+            byte[] buffer = new byte[16 * 1024];
 
             using (var ms = new MemoryStream())
             {


### PR DESCRIPTION
Added OnBeforeStartExternalProcess callback which to NodeServicesOptions (and OutOfProcessNodeInstance, SocketNodeInstance and HttpNodeInstance) to configure environment of the node.exe process to be started, and the path to the node executable itself. Fixes #20