### PR TITLE
Adding support for capturing the output of a node instance for custom…

### DIFF
--- a/src/Microsoft.AspNetCore.NodeServices/Configuration/Configuration.cs
+++ b/src/Microsoft.AspNetCore.NodeServices/Configuration/Configuration.cs
@@ -46,10 +46,10 @@ namespace Microsoft.AspNetCore.NodeServices
                 switch (options.HostingModel)
                 {
                     case NodeHostingModel.Http:
-                        return new HttpNodeInstance(options.ProjectPath, options.WatchFileExtensions, /* port */ 0);
+                        return new HttpNodeInstance(options.ProjectPath, options.WatchFileExtensions, /* port */ 0, options.NodeInstanceOutputLogger);
                     case NodeHostingModel.Socket:
                         var pipeName = "pni-" + Guid.NewGuid().ToString("D"); // Arbitrary non-clashing string
-                        return new SocketNodeInstance(options.ProjectPath, options.WatchFileExtensions, pipeName);
+                        return new SocketNodeInstance(options.ProjectPath, options.WatchFileExtensions, pipeName, options.NodeInstanceOutputLogger);
                     default:
                         throw new ArgumentException("Unknown hosting model: " + options.HostingModel);
                 }

--- a/src/Microsoft.AspNetCore.NodeServices/Configuration/NodeServicesOptions.cs
+++ b/src/Microsoft.AspNetCore.NodeServices/Configuration/NodeServicesOptions.cs
@@ -1,5 +1,6 @@
 using System;
 using Microsoft.AspNetCore.NodeServices.HostingModels;
+using Microsoft.AspNetCore.NodeServices.Util;
 
 namespace Microsoft.AspNetCore.NodeServices
 {
@@ -19,5 +20,6 @@ namespace Microsoft.AspNetCore.NodeServices
         public Func<INodeInstance> NodeInstanceFactory { get; set; }
         public string ProjectPath { get; set; }
         public string[] WatchFileExtensions { get; set; }
+        public INodeInstanceOutputLogger NodeInstanceOutputLogger { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.NodeServices/HostingModels/HttpNodeInstance.cs
+++ b/src/Microsoft.AspNetCore.NodeServices/HostingModels/HttpNodeInstance.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.NodeServices.Util;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
@@ -32,14 +33,15 @@ namespace Microsoft.AspNetCore.NodeServices.HostingModels
         private bool _disposed;
         private int _portNumber;
 
-        public HttpNodeInstance(string projectPath, string[] watchFileExtensions, int port = 0)
+        public HttpNodeInstance(string projectPath, string[] watchFileExtensions, int port = 0, INodeInstanceOutputLogger nodeInstanceOutputLogger = null)
             : base(
                 EmbeddedResourceReader.Read(
                     typeof(HttpNodeInstance),
                     "/Content/Node/entrypoint-http.js"),
                 projectPath,
                 watchFileExtensions,
-                MakeCommandLineOptions(port))
+                MakeCommandLineOptions(port),
+                nodeInstanceOutputLogger)
         {
             _client = new HttpClient();
 		}

--- a/src/Microsoft.AspNetCore.NodeServices/HostingModels/OutOfProcessNodeInstance.cs
+++ b/src/Microsoft.AspNetCore.NodeServices/HostingModels/OutOfProcessNodeInstance.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.NodeServices.Util;
 
 namespace Microsoft.AspNetCore.NodeServices.HostingModels
 {
@@ -26,13 +27,18 @@ namespace Microsoft.AspNetCore.NodeServices.HostingModels
         private readonly Process _nodeProcess;
         private bool _nodeProcessNeedsRestart;
         private readonly string[] _watchFileExtensions;
+        private INodeInstanceOutputLogger _nodeInstanceOutputLogger;
 
         public OutOfProcessNodeInstance(
             string entryPointScript,
             string projectPath,
             string[] watchFileExtensions,
-            string commandLineArguments)
+            string commandLineArguments,
+            INodeInstanceOutputLogger nodeOutputLogger)
         {
+            _nodeInstanceOutputLogger = nodeOutputLogger;
+            if(_nodeInstanceOutputLogger == null)
+                _nodeInstanceOutputLogger = new ConsoleNodeInstanceOutputLogger();
             _entryPointScript = new StringAsTempFile(entryPointScript);
             _nodeProcess = LaunchNodeProcess(_entryPointScript.FileName, projectPath, commandLineArguments);
             _watchFileExtensions = watchFileExtensions;
@@ -73,12 +79,12 @@ namespace Microsoft.AspNetCore.NodeServices.HostingModels
 
         protected virtual void OnOutputDataReceived(string outputData)
         {
-            Console.WriteLine("[Node] " + outputData);
+            _nodeInstanceOutputLogger.LogOutputData(outputData);
         }
 
         protected virtual void OnErrorDataReceived(string errorData)
         {
-            Console.WriteLine("[Node] " + errorData);
+            _nodeInstanceOutputLogger.LogErrorData(errorData);
         }
 
         protected virtual void Dispose(bool disposing)

--- a/src/Microsoft.AspNetCore.NodeServices/HostingModels/SocketNodeInstance.cs
+++ b/src/Microsoft.AspNetCore.NodeServices/HostingModels/SocketNodeInstance.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.NodeServices.HostingModels.PhysicalConnections;
 using Microsoft.AspNetCore.NodeServices.HostingModels.VirtualConnections;
+using Microsoft.AspNetCore.NodeServices.Util;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
@@ -36,13 +37,14 @@ namespace Microsoft.AspNetCore.NodeServices.HostingModels
         private string _socketAddress;
         private VirtualConnectionClient _virtualConnectionClient;
 
-        public SocketNodeInstance(string projectPath, string[] watchFileExtensions, string socketAddress): base(
+        public SocketNodeInstance(string projectPath, string[] watchFileExtensions, string socketAddress, INodeInstanceOutputLogger nodeInstanceOutputLogger = null) : base(
                 EmbeddedResourceReader.Read(
                     typeof(SocketNodeInstance),
                     "/Content/Node/entrypoint-socket.js"),
                 projectPath,
                 watchFileExtensions,
-                MakeNewCommandLineOptions(socketAddress))
+                MakeNewCommandLineOptions(socketAddress),
+                nodeInstanceOutputLogger)
         {
             _socketAddress = socketAddress;
 		}

--- a/src/Microsoft.AspNetCore.NodeServices/Util/ConsoleNodeInstanceOutputLogger.cs
+++ b/src/Microsoft.AspNetCore.NodeServices/Util/ConsoleNodeInstanceOutputLogger.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Microsoft.AspNetCore.NodeServices.Util
+{
+    public class ConsoleNodeInstanceOutputLogger : INodeInstanceOutputLogger
+    {
+        public void LogOutputData(string outputData)
+        {
+            Console.WriteLine("[Node] " + outputData);
+        }
+
+        public void LogErrorData(string errorData)
+        {
+            Console.WriteLine("[Node] " + errorData);
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.NodeServices/Util/INodeInstanceOutputLogger.cs
+++ b/src/Microsoft.AspNetCore.NodeServices/Util/INodeInstanceOutputLogger.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNetCore.NodeServices.Util
+{
+    public interface INodeInstanceOutputLogger
+    {
+        void LogOutputData(string outputData);
+
+        void LogErrorData(string errorData);
+    }
+}


### PR DESCRIPTION
… logging implementations.

Not all implementations rely on stdout for logging and error messages.