### PR TITLE
fix angular's (click) events not being triggered on IE9

### DIFF
--- a/templates/Angular2Spa/ClientApp/boot-client.ts
+++ b/templates/Angular2Spa/ClientApp/boot-client.ts
@@ -1,3 +1,4 @@
+import 'es6-shim';
 require('zone.js');
 import 'bootstrap';
 import 'reflect-metadata';


### PR DESCRIPTION
Fix for angular's (click) event not being triggered on IE9.
Linked with following issue: #172 