### PR TITLE
Dockerfile best practices to speed up builds

### DIFF
--- a/templates/Angular2Spa/Dockerfile
+++ b/templates/Angular2Spa/Dockerfile
@@ -1,13 +1,11 @@
 FROM microsoft/dotnet:latest
 
+RUN apt-get update
+RUN apt-get install -y build-essential nodejs nodejs-legacy
+
 COPY . /app
 
 WORKDIR /app
-
-# Add Node.js to the container. If you don't want to wait for this to install every
-# time you rebuild your container, consider creating an image that has it preinstalled.
-RUN apt-get update
-RUN apt-get install -y build-essential nodejs nodejs-legacy
 
 RUN ["dotnet", "restore"]
 

--- a/templates/Angular2Spa/Dockerfile
+++ b/templates/Angular2Spa/Dockerfile
@@ -3,12 +3,12 @@ FROM microsoft/dotnet:latest
 RUN apt-get update
 RUN apt-get install -y build-essential nodejs nodejs-legacy
 
-COPY . /app
-
 WORKDIR /app
 
+COPY project.json .
 RUN ["dotnet", "restore"]
 
+COPY . /app
 RUN ["dotnet", "build"]
 
 EXPOSE 5000/tcp

--- a/templates/KnockoutSpa/Dockerfile
+++ b/templates/KnockoutSpa/Dockerfile
@@ -1,13 +1,11 @@
 FROM microsoft/dotnet:latest
 
+RUN apt-get update
+RUN apt-get install -y build-essential nodejs nodejs-legacy
+
 COPY . /app
 
 WORKDIR /app
-
-# Add Node.js to the container. If you don't want to wait for this to install every
-# time you rebuild your container, consider creating an image that has it preinstalled.
-RUN apt-get update
-RUN apt-get install -y build-essential nodejs nodejs-legacy
 
 RUN ["dotnet", "restore"]
 

--- a/templates/KnockoutSpa/Dockerfile
+++ b/templates/KnockoutSpa/Dockerfile
@@ -3,12 +3,12 @@ FROM microsoft/dotnet:latest
 RUN apt-get update
 RUN apt-get install -y build-essential nodejs nodejs-legacy
 
-COPY . /app
-
 WORKDIR /app
 
+COPY project.json .
 RUN ["dotnet", "restore"]
 
+COPY . /app
 RUN ["dotnet", "build"]
 
 EXPOSE 5000/tcp

--- a/templates/ReactReduxSpa/Dockerfile
+++ b/templates/ReactReduxSpa/Dockerfile
@@ -1,13 +1,11 @@
 FROM microsoft/dotnet:latest
 
+RUN apt-get update
+RUN apt-get install -y build-essential nodejs nodejs-legacy
+
 COPY . /app
 
 WORKDIR /app
-
-# Add Node.js to the container. If you don't want to wait for this to install every
-# time you rebuild your container, consider creating an image that has it preinstalled.
-RUN apt-get update
-RUN apt-get install -y build-essential nodejs nodejs-legacy
 
 RUN ["dotnet", "restore"]
 

--- a/templates/ReactReduxSpa/Dockerfile
+++ b/templates/ReactReduxSpa/Dockerfile
@@ -3,12 +3,12 @@ FROM microsoft/dotnet:latest
 RUN apt-get update
 RUN apt-get install -y build-essential nodejs nodejs-legacy
 
-COPY . /app
-
 WORKDIR /app
 
+COPY project.json .
 RUN ["dotnet", "restore"]
 
+COPY . /app
 RUN ["dotnet", "build"]
 
 EXPOSE 5000/tcp

--- a/templates/ReactSpa/Dockerfile
+++ b/templates/ReactSpa/Dockerfile
@@ -1,13 +1,11 @@
 FROM microsoft/dotnet:latest
 
+RUN apt-get update
+RUN apt-get install -y build-essential nodejs nodejs-legacy
+
 COPY . /app
 
 WORKDIR /app
-
-# Add Node.js to the container. If you don't want to wait for this to install every
-# time you rebuild your container, consider creating an image that has it preinstalled.
-RUN apt-get update
-RUN apt-get install -y build-essential nodejs nodejs-legacy
 
 RUN ["dotnet", "restore"]
 

--- a/templates/ReactSpa/Dockerfile
+++ b/templates/ReactSpa/Dockerfile
@@ -3,12 +3,12 @@ FROM microsoft/dotnet:latest
 RUN apt-get update
 RUN apt-get install -y build-essential nodejs nodejs-legacy
 
-COPY . /app
-
 WORKDIR /app
 
+COPY project.json .
 RUN ["dotnet", "restore"]
 
+COPY . /app
 RUN ["dotnet", "build"]
 
 EXPOSE 5000/tcp

--- a/templates/WebApplicationBasic/Dockerfile
+++ b/templates/WebApplicationBasic/Dockerfile
@@ -1,11 +1,11 @@
 FROM microsoft/dotnet:latest
 
-COPY . /app
-
 WORKDIR /app
 
+COPY project.json .
 RUN ["dotnet", "restore"]
 
+COPY . /app
 RUN ["dotnet", "build"]
 
 EXPOSE 5000/tcp


### PR DESCRIPTION
I noticed that there was some room for improvement in the Dockerfiles created by the Yeomen generator. There are two parts to it:

* Run the `apt-get` commands before any project-specific commands.
* Copy _only_ `project.json` before running `dotnet restore`, then copy the rest before `dotnet build`.

The [rationale](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#/build-cache) for both these changes is driven by how Docker caches intermediate images in building from a Dockerfile. 

I won't duplicate that explanation here, but this means that Node.js won't need to be reinstalled on every code change and project dependencies won't need to be restored unless `project.json` changes. 

I hope you find this useful. I wouldn't have been able to get started down the ASP.Net SPA path without the generators, so keep up the great work.

**EDIT**: I would have also added a .dockerignore to the templates, but I'm not at all familiar with Yeomen generators and wasn't sure if it was as simple as dropping it in the right place. It's essentially the same syntax as the .gitignore. We don't want any build artifacts from the Docker host making their way into the Docker container.