### PR TITLE
FIxing path separator to address #247

### DIFF
--- a/src/Microsoft.AspNetCore.NodeServices/HostingModels/OutOfProcessNodeInstance.cs
+++ b/src/Microsoft.AspNetCore.NodeServices/HostingModels/OutOfProcessNodeInstance.cs
@@ -126,7 +126,7 @@ If you haven't yet installed node-inspector, you can do so as follows:
             var existingNodePath = Environment.GetEnvironmentVariable("NODE_PATH") ?? string.Empty;
             if (existingNodePath != string.Empty)
             {
-                existingNodePath += ":";
+                existingNodePath += ";";
             }
 
             var nodePathValue = existingNodePath + Path.Combine(projectPath, "node_modules");

--- a/src/Microsoft.AspNetCore.NodeServices/HostingModels/OutOfProcessNodeInstance.cs
+++ b/src/Microsoft.AspNetCore.NodeServices/HostingModels/OutOfProcessNodeInstance.cs
@@ -126,7 +126,7 @@ If you haven't yet installed node-inspector, you can do so as follows:
             var existingNodePath = Environment.GetEnvironmentVariable("NODE_PATH") ?? string.Empty;
             if (existingNodePath != string.Empty)
             {
-                existingNodePath += ";";
+                existingNodePath += Path.PathSeparator;
             }
 
             var nodePathValue = existingNodePath + Path.Combine(projectPath, "node_modules");


### PR DESCRIPTION
When investigating #247 I noticed that the `NODE_PATH` would look something like:

`C:\tmp\.nvm\v6.3.1\node_modules:C:\_code\project\node_modules`

The problem is that the path separator is `:` not `;`.

This fix have resolve the issue in my testing.

## Testing fix

1. Create a new project using the yeoman generator
2. Enable server side rendering
3. Set `NODE_PATH` to have a value (eg: `C:\tmp`)
4. Run the application and experience the error described in #247 
5. Apply patch
6. Run the application successfully