### PR TITLE
Bug(KnockoutSpa): Router TS issue

### DIFF
--- a/templates/KnockoutSpa/ClientApp/router.ts
+++ b/templates/KnockoutSpa/ClientApp/router.ts
@@ -1,5 +1,5 @@
 import * as ko from 'knockout';
-import * as crossroads from 'crossroads';
+var crossroads = require('crossroads');
 
 // This module configures crossroads.js, a routing library. If you prefer, you
 // can use any other routing library (or none at all) as Knockout is designed to

--- a/templates/KnockoutSpa/ClientApp/router.ts
+++ b/templates/KnockoutSpa/ClientApp/router.ts
@@ -1,5 +1,5 @@
 import * as ko from 'knockout';
-var crossroads = require('crossroads');
+import crossroads = require('crossroads');
 
 // This module configures crossroads.js, a routing library. If you prefer, you
 // can use any other routing library (or none at all) as Knockout is designed to


### PR DESCRIPTION
TS erroring out (unable to build) due to `crossroads.normalizeFn = crossroads.NORM_AS_OBJECT;` <-- left hand assignment

```
ERROR in ./ClientApp/router.ts
(21,9): error TS2450: Left-hand side of assignment expression cannot be a constant 
or a read-only property.
```