### PR TITLE
Make the Webpack Dependency in the aspnet-webpack NPM Package a Peer Dependency

### DIFF
--- a/src/Microsoft.AspNetCore.SpaServices/npm/aspnet-webpack/package.json
+++ b/src/Microsoft.AspNetCore.SpaServices/npm/aspnet-webpack/package.json
@@ -18,6 +18,7 @@
     "webpack-externals-plugin": "^1.0.0"
   },
   "devDependencies": {
+    "tsd": "0.6.5",
     "rimraf": "^2.5.4",
     "typescript": "^1.8.10"
   },

--- a/src/Microsoft.AspNetCore.SpaServices/npm/aspnet-webpack/package.json
+++ b/src/Microsoft.AspNetCore.SpaServices/npm/aspnet-webpack/package.json
@@ -14,12 +14,14 @@
     "connect": "^3.4.1",
     "memory-fs": "^0.3.0",
     "require-from-string": "^1.1.0",
-    "webpack": "^1.12.14",
-    "webpack-dev-middleware": "^1.5.1",
+    "webpack-dev-middleware": "^1.6.1",
     "webpack-externals-plugin": "^1.0.0"
   },
   "devDependencies": {
     "rimraf": "^2.5.4",
     "typescript": "^1.8.10"
+  },
+  "peerDependencies": {
+    "webpack": "^1.13.2"
   }
 }


### PR DESCRIPTION
## Make the Webpack Dependency in the aspnet-webpack NPM Package a Peer Dependency

### Proposed Changes
This pull request changes the `package.json` file in the `aspnet-webpack` npm package by moving the webpack dependency from `devDependencies` to `peerDependencies`. This makes the Webpack dependency soft and allows the `webpack-dev-middleware` in `aspnet-webpack` to pickup the Webpack version being used by the user further up the dependency chain. The pull request also adds `tsd` to `devDependencies` to allow the `aspnet-webpack`'s npm prepublish script to run without a global tsd install.

> [**package.json**] Add `webpack` to `peerDependencies`

```json
{
    "peerDependencies": {
        "webpack": "^1.13.2" 
    }
}
```

> [**package.json**] Add `tsd` to `devDependencies`

```json
{
    "devDependencies": {
        "tsd": "0.6.5"
    }
}
```

### Related Issues
This pull request fixes #283