### PR TITLE
Serialize node invocationInfo JSON directly to stream to avoid running out of memory

### DIFF
--- a/src/Microsoft.AspNetCore.NodeServices/HostingModels/SocketNodeInstance.cs
+++ b/src/Microsoft.AspNetCore.NodeServices/HostingModels/SocketNodeInstance.cs
@@ -92,7 +92,7 @@ namespace Microsoft.AspNetCore.NodeServices.HostingModels
                 virtualConnection = _virtualConnectionClient.OpenVirtualConnection();
 
                 // Send request
-                WriteJsonLine(virtualConnection, invocationInfo, cancellationToken);
+                WriteJsonLine(virtualConnection, invocationInfo);
 
                 // Determine what kind of response format is expected
                 if (typeof(T) == typeof(Stream))
@@ -172,7 +172,7 @@ namespace Microsoft.AspNetCore.NodeServices.HostingModels
             base.Dispose(disposing);
         }
 
-        private static void WriteJsonLine(Stream stream, object serializableObject, CancellationToken cancellationToken)
+        private static void WriteJsonLine(Stream stream, object serializableObject)
         {
             using (var streamWriter = new StreamWriter(stream, utf8EncodingWithoutBom, streamBufferSize, true))
             using (var jsonWriter = new JsonTextWriter(streamWriter))


### PR DESCRIPTION
Fixes sending invocation info to the node process when it is first created for the SocketNodeInstance, when serializing >30MB of JSON text and using 32-bit IIS Express (with a .NET Framework 4.5.2 app), which would otherwise result in an OutOfMemoryException at the GetBytes method.

This fix serializes the invocationInfo into a JSON string directly to the stream without double-handling it as a string to reduce the memory footprint of the application. It uses the NewtonsoftJson JsonTextWriter to handle serialization to the stream.

The underlying stream is kept open while the writers are disposed by creating the StreamWriter with 'true' as the last parameter of its constructor (this also requires specifying the buffer size, so I've copied the size used in a method below), and setting the CloseOutput property of the JsonWriter to false.

The cancellationToken is no longer passed through as the method is no longer async - JsonSerializer.serialize doesn't seem to have an async variant. I'm guessing this would have a slight performance impact, so maybe there's a better way of doing this?