### PR TITLE
Update Dockerfile

### DIFF
--- a/templates/Angular2Spa/Dockerfile
+++ b/templates/Angular2Spa/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:latest
+FROM microsoft/dotnet:1.0.0-preview2-onbuild
 
 RUN apt-get update
 RUN apt-get install -y build-essential nodejs nodejs-legacy


### PR DESCRIPTION
The app doesn't run in Docker on base image `microsoft/dotnet:latest` because Microsoft.NETCore.App 1.0.1 isn't installed. Only 1.0.0 is installed. The app runs fine on base image `microsoft/dotnet:1.0.0-preview2-onbuild`.