### PR TITLE
Add '-loader' suffix to all Webpack loader references

### DIFF
--- a/samples/misc/Webpack/webpack.config.dev.js
+++ b/samples/misc/Webpack/webpack.config.dev.js
@@ -2,7 +2,7 @@ module.exports = {
     devtool: 'inline-source-map',
     module: {
         loaders: [
-            { test: /\.less$/, loader: 'style!css!less' }
+            { test: /\.less$/, loader: 'style-loader!css-loader!less-loader' }
         ]
     }
 };

--- a/samples/misc/Webpack/webpack.config.prod.js
+++ b/samples/misc/Webpack/webpack.config.prod.js
@@ -5,7 +5,7 @@ var extractLESS = new ExtractTextPlugin('my-styles.css');
 module.exports = {
     module: {
         loaders: [
-            { test: /\.less$/, loader: extractLESS.extract(['css', 'less']) },
+            { test: /\.less$/, loader: extractLESS.extract(['css-loader', 'less-loader']) },
         ]
     },
     plugins: [

--- a/templates/Angular2Spa/webpack.config.js
+++ b/templates/Angular2Spa/webpack.config.js
@@ -15,7 +15,7 @@ module.exports = merge({
         loaders: [
             { test: /\.ts$/, include: /ClientApp/, loader: 'ts-loader' },
             { test: /\.html$/, loader: 'raw-loader' },
-            { test: /\.css/, loader: extractCSS.extract(['css']) }
+            { test: /\.css/, loader: extractCSS.extract(['css-loader']) }
         ]
     },
     entry: {

--- a/templates/Angular2Spa/webpack.config.vendor.js
+++ b/templates/Angular2Spa/webpack.config.vendor.js
@@ -11,7 +11,7 @@ module.exports = {
     module: {
         loaders: [
             { test: /\.(png|woff|woff2|eot|ttf|svg)$/, loader: 'url-loader?limit=100000' },
-            { test: /\.css/, loader: extractCSS.extract(['css']) }
+            { test: /\.css/, loader: extractCSS.extract(['css-loader']) }
         ]
     },
     entry: {

--- a/templates/KnockoutSpa/ClientApp/components/app-root/app-root.ts
+++ b/templates/KnockoutSpa/ClientApp/components/app-root/app-root.ts
@@ -23,9 +23,9 @@ class AppRootViewModel {
         // to be split into separate files that are then loaded on demand.
         // For docs, see https://github.com/webpack/bundle-loader
         ko.components.register('nav-menu', navMenu);
-        ko.components.register('home-page', require('bundle?lazy!../home-page/home-page'));
-        ko.components.register('counter-example', require('bundle?lazy!../counter-example/counter-example'));
-        ko.components.register('fetch-data', require('bundle?lazy!../fetch-data/fetch-data'));
+        ko.components.register('home-page', require('bundle-loader?lazy!../home-page/home-page'));
+        ko.components.register('counter-example', require('bundle-loader?lazy!../counter-example/counter-example'));
+        ko.components.register('fetch-data', require('bundle-loader?lazy!../fetch-data/fetch-data'));
     }
     
     // To support hot module replacement, this method unregisters the router and KO components.

--- a/templates/KnockoutSpa/ClientApp/webpack-component-loader.ts
+++ b/templates/KnockoutSpa/ClientApp/webpack-component-loader.ts
@@ -2,7 +2,7 @@ import * as ko from 'knockout';
 
 // This Knockout component loader integrates with Webpack's lazy-loaded bundle feature.
 // Having this means you can optionally declare components as follows:
-//   ko.components.register('my-component', require('bundle?lazy!../some-path-to-a-js-or-ts-module'));
+//   ko.components.register('my-component', require('bundle-loader?lazy!../some-path-to-a-js-or-ts-module'));
 // ... and then it will be loaded on demand instead of being loaded up front.
 ko.components.loaders.unshift({
     loadComponent: (name, componentConfig, callback) => {

--- a/templates/KnockoutSpa/webpack.config.dev.js
+++ b/templates/KnockoutSpa/webpack.config.dev.js
@@ -2,7 +2,7 @@ module.exports = {
     devtool: 'inline-source-map',
     module: {
         loaders: [
-            { test: /\.css/, loader: 'style!css' }
+            { test: /\.css/, loader: 'style-loader!css-loader' }
         ]
     }
 };

--- a/templates/KnockoutSpa/webpack.config.prod.js
+++ b/templates/KnockoutSpa/webpack.config.prod.js
@@ -5,7 +5,7 @@ var extractCSS = new ExtractTextPlugin('site.css');
 module.exports = {
     module: {
         loaders: [
-            { test: /\.css/, loader: extractCSS.extract(['css']) },
+            { test: /\.css/, loader: extractCSS.extract(['css-loader']) },
         ]
     },
     plugins: [

--- a/templates/KnockoutSpa/webpack.config.vendor.js
+++ b/templates/KnockoutSpa/webpack.config.vendor.js
@@ -11,7 +11,7 @@ module.exports = {
     module: {
         loaders: [
             { test: /\.(png|woff|woff2|eot|ttf|svg)$/, loader: 'url-loader?limit=100000' },
-            { test: /\.css/, loader: extractCSS.extract(['css']) }
+            { test: /\.css/, loader: extractCSS.extract(['css-loader']) }
         ]
     },
     entry: {

--- a/templates/ReactReduxSpa/webpack.config.js
+++ b/templates/ReactReduxSpa/webpack.config.js
@@ -15,7 +15,7 @@ module.exports = merge({
         loaders: [
             { test: /\.ts(x?)$/, include: /ClientApp/, loader: 'babel-loader' },
             { test: /\.ts(x?)$/, include: /ClientApp/, loader: 'ts-loader' },
-            { test: /\.css/, loader: extractCSS.extract(['css']) }
+            { test: /\.css/, loader: extractCSS.extract(['css-loader']) }
         ]
     },
     entry: {

--- a/templates/ReactReduxSpa/webpack.config.vendor.js
+++ b/templates/ReactReduxSpa/webpack.config.vendor.js
@@ -11,7 +11,7 @@ module.exports = {
     module: {
         loaders: [
             { test: /\.(png|woff|woff2|eot|ttf|svg)$/, loader: 'url-loader?limit=100000' },
-            { test: /\.css/, loader: extractCSS.extract(['css']) }
+            { test: /\.css/, loader: extractCSS.extract(['css-loader']) }
         ]
     },
     entry: {

--- a/templates/ReactSpa/webpack.config.dev.js
+++ b/templates/ReactSpa/webpack.config.dev.js
@@ -2,7 +2,7 @@ module.exports = {
     devtool: 'inline-source-map',
     module: {
         loaders: [
-            { test: /\.css/, loader: 'style!css' }
+            { test: /\.css/, loader: 'style-loader!css-loader' }
         ]
     }
 };

--- a/templates/ReactSpa/webpack.config.prod.js
+++ b/templates/ReactSpa/webpack.config.prod.js
@@ -5,7 +5,7 @@ var extractCSS = new ExtractTextPlugin('site.css');
 module.exports = {
     module: {
         loaders: [
-            { test: /\.css/, loader: extractCSS.extract(['css']) },
+            { test: /\.css/, loader: extractCSS.extract(['css-loader']) },
         ]
     },
     plugins: [

--- a/templates/ReactSpa/webpack.config.vendor.js
+++ b/templates/ReactSpa/webpack.config.vendor.js
@@ -11,7 +11,7 @@ module.exports = {
     module: {
         loaders: [
             { test: /\.(png|woff|woff2|eot|ttf|svg)$/, loader: 'url-loader?limit=100000' },
-            { test: /\.css/, loader: extractCSS.extract(['css']) }
+            { test: /\.css/, loader: extractCSS.extract(['css-loader']) }
         ]
     },
     entry: {

--- a/templates/WebApplicationBasic/webpack.config.js
+++ b/templates/WebApplicationBasic/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = merge({
     module: {
         loaders: [
             { test: /\.ts(x?)$/, include: /ClientApp/, loader: 'ts-loader' },
-            { test: /\.css/, loader: extractCSS.extract(['css']) }
+            { test: /\.css/, loader: extractCSS.extract(['css-loader']) }
         ]
     },
     entry: {

--- a/templates/WebApplicationBasic/webpack.config.vendor.js
+++ b/templates/WebApplicationBasic/webpack.config.vendor.js
@@ -11,7 +11,7 @@ module.exports = {
     module: {
         loaders: [
             { test: /\.(png|woff|woff2|eot|ttf|svg)$/, loader: 'url-loader?limit=100000' },
-            { test: /\.css/, loader: extractCSS.extract(['css']) }
+            { test: /\.css/, loader: extractCSS.extract(['css-loader']) }
         ]
     },
     entry: {


### PR DESCRIPTION
Addresses issue #444 by explicitly adding a `-loader` suffix to all Webpack loader references.