### PR TITLE
Add status code response capabilities from client side routes to server respose

### DIFF
--- a/src/Microsoft.AspNetCore.SpaServices/Prerendering/PrerenderTagHelper.cs
+++ b/src/Microsoft.AspNetCore.SpaServices/Prerendering/PrerenderTagHelper.cs
@@ -129,6 +129,11 @@ namespace Microsoft.AspNetCore.SpaServices.Prerendering
                 return;
             }
 
+            if (result.StatusCode.HasValue)
+            {
+                ViewContext.HttpContext.Response.StatusCode = result.StatusCode.Value;
+            }
+
             // It's some HTML to inject
             output.Content.SetHtmlContent(result.Html);
 

--- a/src/Microsoft.AspNetCore.SpaServices/Prerendering/RenderToStringResult.cs
+++ b/src/Microsoft.AspNetCore.SpaServices/Prerendering/RenderToStringResult.cs
@@ -25,5 +25,12 @@ namespace Microsoft.AspNetCore.SpaServices.Prerendering
         /// to the SPA's routing configuration.
         /// </summary>
         public string RedirectUrl { get; set; }
+
+        /// <summary>
+        /// If set, specifies the HTTP status code that should be sent back with the server response.
+        /// This can be used to pass routes that are determined based on client side routes back to the user if necessary.
+        /// Will default to 200
+        /// </summary>
+        public int? StatusCode { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.SpaServices/npm/aspnet-prerendering/src/PrerenderingInterfaces.d.ts
+++ b/src/Microsoft.AspNetCore.SpaServices/npm/aspnet-prerendering/src/PrerenderingInterfaces.d.ts
@@ -8,6 +8,7 @@ interface RenderToStringCallback {
 
 interface RenderToStringResult {
     html: string;
+    statusCode: number;
     globals?: { [key: string]: any };
 }
 


### PR DESCRIPTION
Had same issue as @TE2s in issue #673. Added the ability for a status code field to be passed from a pre-render script to the tag helper. Tested in my teams project using multiple different status codes.

Looking forward to your feedback.