### PR TITLE
update tsconfig.js to use files instead of paths

### DIFF
--- a/templates/ReactReduxSpa/tsconfig.json
+++ b/templates/ReactReduxSpa/tsconfig.json
@@ -9,7 +9,7 @@
     "skipDefaultLibCheck": true,
     "lib": ["es6", "dom"],
     "types": [ "webpack-env" ],
-    "paths": {
+    "files": {
       // Fix "Duplicate identifier" errors caused by multiple dependencies fetching their own copies of type definitions.
       // We tell TypeScript which type definitions module to treat as the canonical one (instead of combining all of them).
       "history": ["./node_modules/@types/history/index"],

--- a/templates/ReactSpa/tsconfig.json
+++ b/templates/ReactSpa/tsconfig.json
@@ -6,7 +6,7 @@
     "jsx": "preserve",
     "sourceMap": true,
     "skipDefaultLibCheck": true,
-    "paths": {
+    "files": {
       // Fix "Duplicate identifier" errors caused by multiple dependencies fetching their own copies of type definitions.
       // We tell TypeScript which type definitions module to treat as the canonical one (instead of combining all of them).
       "history": ["./node_modules/@types/history/index"],


### PR DESCRIPTION
Fixes #729. 

Changing `paths` to `files` in the `tsconfig.js` seems to fix the problem. I am no longer getting errors while in development mode.  This seems to be the correct way to do it based on the [documentation](http://www.typescriptlang.org/docs/handbook/tsconfig-json.html). I see no reference to `paths` being used