### PR TITLE
Added babel-loader caching to improve subsequent build times.

### DIFF
--- a/templates/ReactReduxSpa/webpack.config.js
+++ b/templates/ReactReduxSpa/webpack.config.js
@@ -10,14 +10,14 @@ module.exports = (env) => {
     // Configuration in common to both client-side and server-side bundles
     const sharedConfig = () => ({
         stats: { modules: false },
-        resolve: { extensions: [ '.js', '.jsx', '.ts', '.tsx' ] },
+        resolve: { extensions: ['.js', '.jsx', '.ts', '.tsx'] },
         output: {
             filename: '[name].js',
             publicPath: '/dist/' // Webpack dev middleware, if enabled, handles requests for this URL prefix
         },
         module: {
             rules: [
-                { test: /\.tsx?$/, include: /ClientApp/, use: 'babel-loader' },
+                { test: /\.tsx?$/, include: /ClientApp/, use: { loader: 'babel-loader', options: { cacheDirectory: true } } },
                 { test: /\.tsx?$/, include: /ClientApp/, use: 'awesome-typescript-loader?silent=true' }
             ]
         },

--- a/templates/ReactSpa/webpack.config.js
+++ b/templates/ReactSpa/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = (env) => {
     return [{
         stats: { modules: false },
         entry: { 'main': './ClientApp/boot.tsx' },
-        resolve: { extensions: [ '.js', '.jsx', '.ts', '.tsx' ] },
+        resolve: { extensions: ['.js', '.jsx', '.ts', '.tsx'] },
         output: {
             path: path.join(__dirname, bundleOutputDir),
             filename: '[name].js',
@@ -17,7 +17,7 @@ module.exports = (env) => {
         },
         module: {
             rules: [
-                { test: /\.ts(x?)$/, include: /ClientApp/, use: 'babel-loader' },
+                { test: /\.ts(x?)$/, include: /ClientApp/, use: { loader: 'babel-loader', options: { cacheDirectory: true } } },
                 { test: /\.tsx?$/, include: /ClientApp/, use: 'awesome-typescript-loader?silent=true' },
                 { test: /\.css$/, use: isDevBuild ? ['style-loader', 'css-loader'] : ExtractTextPlugin.extract({ use: 'css-loader' }) },
                 { test: /\.(png|jpg|jpeg|gif|svg)$/, use: 'url-loader?limit=25000' }


### PR DESCRIPTION
Added babel-loader caching which significantly improves build times. This is also used in the create-react-app template.

First run:
```
$ webpack
(node:2164) DeprecationWarning: loaderUtils.parseQuery() received a non-string value which can be problematic, see https://github.com/webpack/loader-utils/issues/56
parseQuery() will be replaced with getOptions() in the next major version of loader-utils.
Hash: f657172a5ca6dcdcb4ddfb908cb42dfef18c1ea5
Version: webpack 2.2.1
Child
    Hash: f657172a5ca6dcdcb4dd
    Time: 11244ms
                 Asset      Size  Chunks             Chunk Names
        main-client.js   49.7 kB       0  [emitted]  main-client
              site.css   1.56 kB       0  [emitted]  main-client
    main-client.js.map   31.6 kB       0  [emitted]  main-client
          site.css.map  85 bytes       0  [emitted]  main-client
Child
    Hash: fb908cb42dfef18c1ea5
    Time: 11228ms
             Asset     Size  Chunks             Chunk Names
    main-server.js  94.2 kB       0  [emitted]  main-server
```

Subsequent run:
```
$ webpack
(node:4936) DeprecationWarning: loaderUtils.parseQuery() received a non-string value which can be problematic, see https://github.com/webpack/loader-utils/issues/56
parseQuery() will be replaced with getOptions() in the next major version of loader-utils.
Hash: f657172a5ca6dcdcb4ddfb908cb42dfef18c1ea5
Version: webpack 2.2.1
Child
    Hash: f657172a5ca6dcdcb4dd
    Time: 3588ms
                 Asset      Size  Chunks             Chunk Names
        main-client.js   49.7 kB       0  [emitted]  main-client
              site.css   1.56 kB       0  [emitted]  main-client
    main-client.js.map   31.6 kB       0  [emitted]  main-client
          site.css.map  85 bytes       0  [emitted]  main-client
Child
    Hash: fb908cb42dfef18c1ea5
    Time: 3572ms
             Asset     Size  Chunks             Chunk Names
    main-server.js  94.2 kB       0  [emitted]  main-server
```