### PR TITLE
Update to latest released webpack 2

### DIFF
--- a/src/Microsoft.AspNetCore.SpaServices/npm/aspnet-webpack/package.json
+++ b/src/Microsoft.AspNetCore.SpaServices/npm/aspnet-webpack/package.json
@@ -33,6 +33,6 @@
     "webpack": "^1.13.2"
   },
   "peerDependencies": {
-    "webpack": "^1.13.2 || ^2.1.0-beta"
+    "webpack": "^1.13.2 || ^2.2.0"
   }
 }


### PR DESCRIPTION
installing your currently react-redux-spa template and running does not work due to server side rendering.
I have webpack installed globally (which installs 2.2)
I read I should try to install aspnet-webpack globally, which failed because it requires 1.13 or rc.