### PR TITLE
Console type needs exe

### DIFF
--- a/samples/misc/LatencyTest/LatencyTest.csproj
+++ b/samples/misc/LatencyTest/LatencyTest.csproj
@@ -5,6 +5,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp1.1</TargetFramework>
     <IsPackable>false</IsPackable>
+    <OutputType>exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
`Project Sdk="Microsoft.NET.Sdk"` needs `<OutputType>exe</OutputType>` or it thinks its a library