### PR TITLE
feat(css minimize): add CSS minification in production build for all templates.

### DIFF
--- a/templates/Angular2Spa/webpack.config.js
+++ b/templates/Angular2Spa/webpack.config.js
@@ -18,7 +18,7 @@ module.exports = (env) => {
             rules: [
                 { test: /\.ts$/, include: /ClientApp/, use: ['awesome-typescript-loader?silent=true', 'angular2-template-loader'] },
                 { test: /\.html$/, use: 'html-loader?minimize=false' },
-                { test: /\.css$/, use: ['to-string-loader', 'css-loader'] },
+                { test: /\.css$/, use: [ 'to-string-loader', isDevBuild ? 'css-loader' : 'css-loader?minimize' ] },
                 { test: /\.(png|jpg|jpeg|gif|svg)$/, use: 'url-loader?limit=25000' }
             ]
         },

--- a/templates/Angular2Spa/webpack.config.vendor.js
+++ b/templates/Angular2Spa/webpack.config.vendor.js
@@ -51,7 +51,7 @@ module.exports = (env) => {
         output: { path: path.join(__dirname, 'wwwroot', 'dist') },
         module: {
             rules: [
-                { test: /\.css(\?|$)/, use: extractCSS.extract({ use: 'css-loader' }) }
+                { test: /\.css(\?|$)/, use: extractCSS.extract({ use: isDevBuild ? 'css-loader' : 'css-loader?minimize' }) }
             ]
         },
         plugins: [
@@ -73,7 +73,7 @@ module.exports = (env) => {
             libraryTarget: 'commonjs2',
         },
         module: {
-            rules: [ { test: /\.css(\?|$)/, use: ['to-string-loader', 'css-loader'] } ]
+            rules: [ { test: /\.css(\?|$)/, use: ['to-string-loader', isDevBuild ? 'css-loader' : 'css-loader?minimize' ] } ]
         },
         entry: { vendor: ['aspnet-prerendering'] },
         plugins: [

--- a/templates/AureliaSpa/webpack.config.js
+++ b/templates/AureliaSpa/webpack.config.js
@@ -16,7 +16,7 @@ module.exports = {
         loaders: [
             { test: /\.ts$/, include: /ClientApp/, loader: 'ts-loader', query: { silent: true } },
             { test: /\.html$/, loader: 'html-loader' },
-            { test: /\.css$/, loaders: [ 'style-loader', 'css-loader' ] },
+            { test: /\.css$/, loaders: [ 'style-loader', isDevBuild ? 'css-loader' : 'css-loader?minimize' ] },
             { test: /\.(png|woff|woff2|eot|ttf|svg)$/, loader: 'url-loader?limit=100000' },
             { test: /\.json$/, loader: 'json-loader' }
         ]

--- a/templates/AureliaSpa/webpack.config.vendor.js
+++ b/templates/AureliaSpa/webpack.config.vendor.js
@@ -11,7 +11,7 @@ module.exports = {
     module: {
         loaders: [
             { test: /\.(png|woff|woff2|eot|ttf|svg)(\?|$)/, loader: 'url-loader?limit=100000' },
-            { test: /\.css(\?|$)/, loader: extractCSS.extract(['css-loader']) }
+            { test: /\.css(\?|$)/, loader: extractCSS.extract([ isDevBuild ? 'css-loader' : 'css-loader?minimize' ]) }
         ]
     },
     entry: {

--- a/templates/KnockoutSpa/webpack.config.js
+++ b/templates/KnockoutSpa/webpack.config.js
@@ -19,7 +19,7 @@ module.exports = (env) => {
             rules: [
                 { test: /\.ts$/, include: /ClientApp/, use: 'awesome-typescript-loader?silent=true' },
                 { test: /\.html$/, use: 'raw-loader' },
-                { test: /\.css$/, use: isDevBuild ? ['style-loader', 'css-loader'] : ExtractTextPlugin.extract({ use: 'css-loader' }) },
+                { test: /\.css$/, use: isDevBuild ? [ 'style-loader', 'css-loader' ] : ExtractTextPlugin.extract({ use: 'css-loader?minimize' }) },
                 { test: /\.(png|jpg|jpeg|gif|svg)$/, use: 'url-loader?limit=25000' }
             ]
         },

--- a/templates/KnockoutSpa/webpack.config.vendor.js
+++ b/templates/KnockoutSpa/webpack.config.vendor.js
@@ -13,7 +13,7 @@ module.exports = (env) => {
         module: {
             rules: [
                 { test: /\.(png|woff|woff2|eot|ttf|svg)(\?|$)/, use: 'url-loader?limit=100000' },
-                { test: /\.css(\?|$)/, use: extractCSS.extract({ use: 'css-loader' }) }
+                { test: /\.css(\?|$)/, use: extractCSS.extract({ use: isDevBuild ? 'css-loader' : 'css-loader?minimize' }) }
             ]
         },
         entry: {

--- a/templates/ReactReduxSpa/webpack.config.js
+++ b/templates/ReactReduxSpa/webpack.config.js
@@ -30,7 +30,7 @@ module.exports = (env) => {
         entry: { 'main-client': './ClientApp/boot-client.tsx' },
         module: {
             rules: [
-                { test: /\.css$/, use: ExtractTextPlugin.extract({ use: 'css-loader' }) },
+                { test: /\.css$/, use: ExtractTextPlugin.extract({ use: isDevBuild ? 'css-loader' : 'css-loader?minimize' }) },
                 { test: /\.(png|jpg|jpeg|gif|svg)$/, use: 'url-loader?limit=25000' }
             ]
         },

--- a/templates/ReactReduxSpa/webpack.config.vendor.js
+++ b/templates/ReactReduxSpa/webpack.config.vendor.js
@@ -49,7 +49,7 @@ module.exports = (env) => {
         output: { path: path.join(__dirname, 'wwwroot', 'dist') },
         module: {
             rules: [
-                { test: /\.css(\?|$)/, use: extractCSS.extract({ use: 'css-loader' }) }
+                { test: /\.css(\?|$)/, use: extractCSS.extract({ use: isDevBuild ? 'css-loader' : 'css-loader?minimize' }) }
             ]
         },
         plugins: [
@@ -71,7 +71,7 @@ module.exports = (env) => {
             libraryTarget: 'commonjs2',
         },
         module: {
-            rules: [ { test: /\.css(\?|$)/, use: 'css-loader' } ]
+            rules: [ { test: /\.css(\?|$)/, use: isDevBuild ? 'css-loader' : 'css-loader?minimize' } ]
         },
         entry: { vendor: ['aspnet-prerendering', 'react-dom/server'] },
         plugins: [

--- a/templates/ReactSpa/webpack.config.js
+++ b/templates/ReactSpa/webpack.config.js
@@ -19,7 +19,7 @@ module.exports = (env) => {
             rules: [
                 { test: /\.ts(x?)$/, include: /ClientApp/, use: { loader: 'babel-loader', options: { cacheDirectory: true } } },
                 { test: /\.tsx?$/, include: /ClientApp/, use: 'awesome-typescript-loader?silent=true' },
-                { test: /\.css$/, use: isDevBuild ? ['style-loader', 'css-loader'] : ExtractTextPlugin.extract({ use: 'css-loader' }) },
+                { test: /\.css$/, use: isDevBuild ? ['style-loader', 'css-loader'] : ExtractTextPlugin.extract({ use: 'css-loader?minimize' }) },
                 { test: /\.(png|jpg|jpeg|gif|svg)$/, use: 'url-loader?limit=25000' }
             ]
         },

--- a/templates/ReactSpa/webpack.config.vendor.js
+++ b/templates/ReactSpa/webpack.config.vendor.js
@@ -13,7 +13,7 @@ module.exports = (env) => {
         module: {
             rules: [
                 { test: /\.(png|woff|woff2|eot|ttf|svg)(\?|$)/, use: 'url-loader?limit=100000' },
-                { test: /\.css(\?|$)/, use: extractCSS.extract(['css-loader']) }
+                { test: /\.css(\?|$)/, use: extractCSS.extract([ isDevBuild ? 'css-loader' : 'css-loader?minimize' ]) }
             ]
         },
         entry: {

--- a/templates/VueSpa/webpack.config.js
+++ b/templates/VueSpa/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = (env) => {
             rules: [
                 { test: /\.vue\.html$/, include: /ClientApp/, loader: 'vue-loader', options: { loaders: { js: 'awesome-typescript-loader?silent=true' } } },
                 { test: /\.ts$/, include: /ClientApp/, use: 'awesome-typescript-loader?silent=true' },
-                { test: /\.css$/, use: isDevBuild ? ['style-loader', 'css-loader'] : ExtractTextPlugin.extract({ use: 'css-loader' }) },
+                { test: /\.css$/, use: isDevBuild ? [ 'style-loader', 'css-loader' ] : ExtractTextPlugin.extract({ use: 'css-loader?minimize' }) },
                 { test: /\.(png|jpg|jpeg|gif|svg)$/, use: 'url-loader?limit=25000' }
             ]
         },

--- a/templates/VueSpa/webpack.config.vendor.js
+++ b/templates/VueSpa/webpack.config.vendor.js
@@ -22,7 +22,7 @@ module.exports = (env) => {
         },
         module: {
             rules: [
-                { test: /\.css(\?|$)/, use: extractCSS.extract({ use: 'css-loader' }) },
+                { test: /\.css(\?|$)/, use: extractCSS.extract({ use: isDevBuild ? 'css-loader' : 'css-loader?minimize' }) },
                 { test: /\.(png|woff|woff2|eot|ttf|svg)(\?|$)/, use: 'url-loader?limit=100000' }
             ]
         },

--- a/templates/WebApplicationBasic/webpack.config.js
+++ b/templates/WebApplicationBasic/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = merge({
     module: {
         loaders: [
             { test: /\.ts(x?)$/, include: /ClientApp/, loader: 'ts-loader?silent=true' },
-            { test: /\.css/, loader: extractCSS.extract(['css-loader']) }
+            { test: /\.css/, loader: extractCSS.extract([ isDevelopment ? 'css-loader' : 'css-loader?minimize' ]) }
         ]
     },
     entry: {

--- a/templates/WebApplicationBasic/webpack.config.vendor.js
+++ b/templates/WebApplicationBasic/webpack.config.vendor.js
@@ -11,7 +11,7 @@ module.exports = {
     module: {
         loaders: [
             { test: /\.(png|woff|woff2|eot|ttf|svg)$/, loader: 'url-loader?limit=100000' },
-            { test: /\.css/, loader: extractCSS.extract(['css-loader']) }
+            { test: /\.css/, loader: extractCSS.extract([ isDevelopment ? 'css-loader' : 'css-loader?minimize' ]) }
         ]
     },
     entry: {


### PR DESCRIPTION
As discussed on #844, this PR allows webpack to compress all CSS using the `minimize` property from the [css-loader](https://github.com/webpack-contrib/css-loader) plugin. It only applies when `--env.prod` is provided.

Please note this will also compress any css passed through webpack, therefore you should expect a small reduction in size on files other than `vendor.css`. Out of curiosity, I'm posting a comparison for each template, showing all the affected files their corresponding sizes before and after this change.

Finally, I also would like to highlight the following passage from the css-loader project:

> In some cases the minification is destructive to the css, so you can provide some options to it....

Although I couldn't find any errors while testing the templates, I encourage everyone to read the css-loader documentation in case of a css compression error.

- **Angular2Spa Template**

    | File | css-loader | css-loader?minimize | Diff (%) |
    | --- | ---- | --- | ----| 
    | vendor.css | 315kB | 286kB | 29kB (9.21%) | 
    | main-client.js | 12.2kB | 11.1kB | 1.1kB (9.02%) |
    | main-server.js | 150kB | 146kB | 4kB (2.67%) |
    | *Total* |  *477.2kB* | *443.1kB* | **34.1kB (7.15%)** |

- **AureliaSpa Template**

    | File | css-loader | css-loader?minimize | Diff (%) |
    | --- | ---- | --- | ----| 
    | vendor.css | 315kB | 286kB | 29kB (9.21%) | 
    | app.js | 26.4kB | 26.1kB | 0.3kB (1.14%) |
    | *Total* |  *341.4kB* | *312.1kB* | **29.3kB (8.58%)** |

- **KnockoutSpa Template**

    | File | css-loader | css-loader?minimize | Diff (%) |
    | --- | ---- | --- | ----| 
    | vendor.css | 315kB | 286kB | 29kB (9.21%) | 
    | 0.js | 1.17kB | 1.12kB | 0.05kB (4.27%) |
    | 1.js | 2.01kB | 1.98kB | 0.03kB (1.49%) |
    | 2.js | 0.577kB | 0.563kB | 0.014kB (2.43%) |
    | main.js | 5.99kB | 5.90kB | 0.9kB (1.5%) |
    | site.css | 1.52kB | 0.729kB | 0.791kB (52%) |
    | *Total* |  *326.2kB* | *296.2kB* | **29.9kB (9.19%)** |

- **ReactReduxSpa Template**

    | File | css-loader | css-loader?minimize | Diff (%) |
    | --- | ---- | --- | ----| 
    | vendor.css | 315kB | 286kB | 29kB (9.21%) | 
    | main-server.js | 94.2kB | 93kB | 1.2kB (1.27%) |
    | site.css | 1.52kB | 0.729kB | 0.791kB (52%) |
    | *Total* |  *410.7kB* | *379.7kB* | **30.9kB (7.55%)** |

- **ReactSpa Template**

    | File | css-loader | css-loader?minimize | Diff (%) |
    | --- | ---- | --- | ----| 
    | vendor.css | 315kB | 286kB | 29kB (9.21%) | 
    | site.css | 1.52kB | 0.729kB | 0.791kB (52%) |
    | *Total* |  *316.5kB* | *286.7kB* | **29.7kB (9.41%)** |

- **VueSpa Template**

    | File | css-loader | css-loader?minimize | Diff (%) |
    | --- | ---- | --- | ----| 
    | vendor.css | 315kB | 286kB | 29kB (9.21%) | 
    | main.js | 21.8kB | 21.6kB | 0.2kB (0.9%) |
    | *Total* |  *336.8kB* | *307.6kB* | **29.2kB (8.67%)** |

Please, feel free to recommend/perform any necessary modifications.
