### PR TITLE
V1.0.x

### DIFF
--- a/templates/Angular2Spa/ClientApp/app/components/fetchdata/fetchdata.component.ts
+++ b/templates/Angular2Spa/ClientApp/app/components/fetchdata/fetchdata.component.ts
@@ -10,7 +10,7 @@ export class FetchDataComponent {
 
     constructor(http: Http) {
         http.get('/api/SampleData/WeatherForecasts').subscribe(result => {
-            this.forecasts = result.json();
+            this.forecasts = result.json() as WeatherForecast[];
         });
     }
 }

--- a/templates/AureliaSpa/ClientApp/app/components/fetchdata/fetchdata.ts
+++ b/templates/AureliaSpa/ClientApp/app/components/fetchdata/fetchdata.ts
@@ -11,9 +11,9 @@ export class Fetchdata {
 
     constructor(http: HttpClient) {
         http.fetch('/api/SampleData/WeatherForecasts')
-            .then(result => result.json())
+            .then(result => result.json() as Promise<WeatherForecast[]>)
             .then(data => {
-                this.forecasts = data as any;
+                this.forecasts = data;
             });
     }
 }

--- a/templates/KnockoutSpa/ClientApp/components/fetch-data/fetch-data.ts
+++ b/templates/KnockoutSpa/ClientApp/components/fetch-data/fetch-data.ts
@@ -13,8 +13,8 @@ class FetchDataViewModel {
 
     constructor() {
         fetch('/api/SampleData/WeatherForecasts')
-            .then(response => response.json())
-            .then((data: WeatherForecast[]) => {
+            .then(response => response.json() as Promise<WeatherForecast[]>)
+            .then(data => {
                 this.forecasts(data);
             });
     }

--- a/templates/ReactReduxSpa/ClientApp/store/WeatherForecasts.ts
+++ b/templates/ReactReduxSpa/ClientApp/store/WeatherForecasts.ts
@@ -46,8 +46,8 @@ export const actionCreators = {
         // Only load data if it's something we don't already have (and are not already loading)
         if (startDateIndex !== getState().weatherForecasts.startDateIndex) {
             let fetchTask = fetch(`/api/SampleData/WeatherForecasts?startDateIndex=${ startDateIndex }`)
-                .then(response => response.json())
-                .then((data: WeatherForecast[]) => {
+                .then(response => response.json() as Promise<WeatherForecast[]>)
+                .then(data => {
                     dispatch({ type: 'RECEIVE_WEATHER_FORECASTS', startDateIndex: startDateIndex, forecasts: data });
                 });
 

--- a/templates/ReactSpa/ClientApp/components/FetchData.tsx
+++ b/templates/ReactSpa/ClientApp/components/FetchData.tsx
@@ -12,8 +12,8 @@ export class FetchData extends React.Component<any, FetchDataExampleState> {
         this.state = { forecasts: [], loading: true };
 
         fetch('/api/SampleData/WeatherForecasts')
-            .then(response => response.json())
-            .then((data: WeatherForecast[]) => {
+            .then(response => response.json() as Promise<WeatherForecast[]>)
+            .then(data => {
                 this.setState({ forecasts: data, loading: false });
             });
     }

--- a/templates/package-builder/src/yeoman/package.json
+++ b/templates/package-builder/src/yeoman/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-aspnetcore-spa",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Single-Page App templates for ASP.NET Core",
   "author": "Microsoft",
   "license": "Apache-2.0",


### PR DESCRIPTION
Browser to remember client side routing history and also server side routing.

Assume we have client side routing as below:
http://localhost:5000/
http://localhost:5000/counter
http://localhost:5000/fetchdata

We also have the routing as below which is not part of client side routing. This will make a request to server to Home Controller and TP action
http://localhost:5000/home/tp

Every work fine except the browser does not keep history of this server side routing when we access any client side routing park.

For instance, I access http://localhost:5000/home/tp
then http://localhost:5000/
then http://localhost:5000/counter

When I clieck Back in browser, it stop at  http://localhost:5000/. It does not track http://localhost:5000/home/tp in history.

I guess React-Router have remove all history from browser to manage history in their code.

Thanks,