### PR TITLE
Allow proxy middleware to abort long running connections.

### DIFF
--- a/src/Microsoft.AspNetCore.SpaServices/Webpack/ConditionalProxyMiddleware.cs
+++ b/src/Microsoft.AspNetCore.SpaServices/Webpack/ConditionalProxyMiddleware.cs
@@ -98,7 +98,7 @@ namespace Microsoft.AspNetCore.SpaServices.Webpack
 
                 using (var responseStream = await responseMessage.Content.ReadAsStreamAsync())
                 {
-                    await responseStream.CopyToAsync(context.Response.Body, BUFFER_SIZE, context.RequestAborted);
+                    await responseStream.CopyToAsync(context.Response.Body, DefaultHttpBufferSize, context.RequestAborted);
                 }
 
                 return true;

--- a/src/Microsoft.AspNetCore.SpaServices/Webpack/ConditionalProxyMiddleware.cs
+++ b/src/Microsoft.AspNetCore.SpaServices/Webpack/ConditionalProxyMiddleware.cs
@@ -16,7 +16,8 @@ namespace Microsoft.AspNetCore.SpaServices.Webpack
     /// </summary>
     internal class ConditionalProxyMiddleware
     {
-        private const int BUFFER_SIZE = 1024;
+        private const int DefaultHttpBufferSize = 4096;
+
         private readonly HttpClient _httpClient;
         private readonly RequestDelegate _next;
         private readonly ConditionalProxyMiddlewareOptions _options;


### PR DESCRIPTION
The conditional proxy middleware that is used for connecting to the webpack dev server was leaving lingering connections when proxying long-running HTTP requests like those used for hot reloading.

This was happening because the `CancellationTokenSource` which lives on the `HttpContext` was never getting called after the initial `SendAsync` which completes after headers are sent.

The fix is simply to ensure that we respect the cancellation token when copying from the upstream response.

Note: I noticed this because when using .Net 4.6 plus System.Net.Http >= 4.3.1, you can only have 2 concurrent `HttpClient` requests active at a time because this change: dotnet/corefx#15036 uses the `HttpClientHandler.MaxConnectionsPerServer` with a default of 2. What was happening was that if I reloaded the page once or twice the hot module reloading wouldn't connect to webpack because it wouldn't let any more connections through because there were a couple lingering threads. It also might be worth changing `HttpClientHandler.MaxConnectionsPerServer` to something higher because even with this change the connections don't close immediately so several quick reloads can get you in the same position. Picking that default concurrency was out of scope for this PR though, I felt.