### PR TITLE
Templates: update React's component's State and Property type

### DIFF
--- a/templates/ReactReduxSpa/ClientApp/components/Counter.tsx
+++ b/templates/ReactReduxSpa/ClientApp/components/Counter.tsx
@@ -7,7 +7,7 @@ import * as WeatherForecasts from '../store/WeatherForecasts';
 
 type CounterProps = CounterStore.CounterState & typeof CounterStore.actionCreators;
 
-class Counter extends React.Component<CounterProps, void> {
+class Counter extends React.Component<CounterProps, {}> {
     public render() {
         return <div>
             <h1>Counter</h1>

--- a/templates/ReactReduxSpa/ClientApp/components/FetchData.tsx
+++ b/templates/ReactReduxSpa/ClientApp/components/FetchData.tsx
@@ -10,7 +10,7 @@ type WeatherForecastProps =
     & typeof WeatherForecastsState.actionCreators   // ... plus action creators we've requested
     & { params: { startDateIndex: string } };       // ... plus incoming routing parameters
 
-class FetchData extends React.Component<WeatherForecastProps, void> {
+class FetchData extends React.Component<WeatherForecastProps, {}> {
     componentWillMount() {
         // This method runs when the component is first added to the page
         let startDateIndex = parseInt(this.props.params.startDateIndex) || 0;

--- a/templates/ReactReduxSpa/ClientApp/components/Home.tsx
+++ b/templates/ReactReduxSpa/ClientApp/components/Home.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-export default class Home extends React.Component<void, void> {
+export default class Home extends React.Component<{}, {}> {
     public render() {
         return <div>
             <h1>Hello, world!</h1>

--- a/templates/ReactReduxSpa/ClientApp/components/Layout.tsx
+++ b/templates/ReactReduxSpa/ClientApp/components/Layout.tsx
@@ -5,7 +5,7 @@ export interface LayoutProps {
     body: React.ReactElement<any>;
 }
 
-export class Layout extends React.Component<LayoutProps, void> {
+export class Layout extends React.Component<LayoutProps, {}> {
     public render() {
         return <div className='container-fluid'>
             <div className='row'>

--- a/templates/ReactReduxSpa/ClientApp/components/NavMenu.tsx
+++ b/templates/ReactReduxSpa/ClientApp/components/NavMenu.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Link } from 'react-router';
 
-export class NavMenu extends React.Component<any, void> {
+export class NavMenu extends React.Component<{}, {}> {
     public render() {
         return <div className='main-nav'>
                 <div className='navbar navbar-inverse'>

--- a/templates/ReactSpa/ClientApp/components/Counter.tsx
+++ b/templates/ReactSpa/ClientApp/components/Counter.tsx
@@ -4,7 +4,7 @@ interface CounterState {
     currentCount: number;
 }
 
-export class Counter extends React.Component<any, CounterState> {
+export class Counter extends React.Component<{}, CounterState> {
     constructor() {
         super();
         this.state = { currentCount: 0 };

--- a/templates/ReactSpa/ClientApp/components/FetchData.tsx
+++ b/templates/ReactSpa/ClientApp/components/FetchData.tsx
@@ -6,7 +6,7 @@ interface FetchDataExampleState {
     loading: boolean;
 }
 
-export class FetchData extends React.Component<any, FetchDataExampleState> {
+export class FetchData extends React.Component<{}, FetchDataExampleState> {
     constructor() {
         super();
         this.state = { forecasts: [], loading: true };

--- a/templates/ReactSpa/ClientApp/components/Home.tsx
+++ b/templates/ReactSpa/ClientApp/components/Home.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-export class Home extends React.Component<any, void> {
+export class Home extends React.Component<{}, {}> {
     public render() {
         return <div>
             <h1>Hello, world!</h1>

--- a/templates/ReactSpa/ClientApp/components/Layout.tsx
+++ b/templates/ReactSpa/ClientApp/components/Layout.tsx
@@ -5,7 +5,7 @@ export interface LayoutProps {
     body: React.ReactElement<any>;
 }
 
-export class Layout extends React.Component<LayoutProps, void> {
+export class Layout extends React.Component<LayoutProps, {}> {
     public render() {
         return <div className='container-fluid'>
             <div className='row'>

--- a/templates/ReactSpa/ClientApp/components/NavMenu.tsx
+++ b/templates/ReactSpa/ClientApp/components/NavMenu.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Link } from 'react-router';
 
-export class NavMenu extends React.Component<any, void> {
+export class NavMenu extends React.Component<{}, {}> {
     public render() {
         return <div className='main-nav'>
                 <div className='navbar navbar-inverse'>


### PR DESCRIPTION
The React templates used `any` and `void` as State and Property types for React.Component, even though it should be `{}`.