### PR TITLE
Switched from av-ts to vue-property-decorator and vue-class-component

### DIFF
--- a/templates/VueSpa/ClientApp/components/app/app.ts
+++ b/templates/VueSpa/ClientApp/components/app/app.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import { Component } from 'av-ts';
+import { Component } from 'vue-property-decorator';
 
 @Component({
     components: {

--- a/templates/VueSpa/ClientApp/components/counter/counter.ts
+++ b/templates/VueSpa/ClientApp/components/counter/counter.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import { Component } from 'av-ts';
+import { Component } from 'vue-property-decorator';
 
 @Component
 export default class CounterComponent extends Vue {

--- a/templates/VueSpa/ClientApp/components/fetchdata/fetchdata.ts
+++ b/templates/VueSpa/ClientApp/components/fetchdata/fetchdata.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import { Component, Lifecycle } from 'av-ts';
+import { Component } from 'vue-property-decorator';
 
 interface WeatherForecast {
     dateFormatted: string;
@@ -12,7 +12,7 @@ interface WeatherForecast {
 export default class FetchDataComponent extends Vue {
     forecasts: WeatherForecast[] = [];
 
-    @Lifecycle mounted() {
+    mounted() {
         fetch('/api/SampleData/WeatherForecasts')
             .then(response => response.json() as Promise<WeatherForecast[]>)
             .then(data => {

--- a/templates/VueSpa/package.json
+++ b/templates/VueSpa/package.json
@@ -4,7 +4,6 @@
   "devDependencies": {
     "@types/requirejs": "^2.1.28",
     "aspnet-webpack": "^1.0.27",
-    "av-ts": "^0.7.1",
     "awesome-typescript-loader": "^3.0.0",
     "bootstrap": "^3.3.6",
     "css-loader": "^0.25.0",
@@ -17,7 +16,9 @@
     "typescript": "^2.2.1",
     "url-loader": "^0.5.7",
     "vue": "^2.2.2",
+    "vue-class-component": "^5.0.1",
     "vue-loader": "^11.1.4",
+    "vue-property-decorator": "^5.0.1",
     "vue-router": "^2.3.0",
     "vue-template-compiler": "^2.2.2",
     "webpack": "^2.2.0",


### PR DESCRIPTION
For more on these packages, there is a good guide here: https://alligator.io/vuejs/typescript-class-components/

[vue-class-component](https://github.com/vuejs/vue-class-component) is an `official companion library` to VueJS ([see here](https://vuejs.org/v2/guide/typescript.html#Class-Style-Vue-Components)) with contributor support from the VueJS author.

This PR simply makes the replacement. Ref #919 