### PR TITLE
Add core-js dependency

### DIFF
--- a/templates/Angular2Spa/package.json
+++ b/templates/Angular2Spa/package.json
@@ -22,6 +22,7 @@
     "aspnet-webpack": "^1.0.17",
     "awesome-typescript-loader": "^3.0.0",
     "bootstrap": "^3.3.7",
+    "core-js": "^2.4.1",
     "css": "^2.2.1",
     "css-loader": "^0.25.0",
     "es6-shim": "^0.35.1",


### PR DESCRIPTION
When I run webpack on the angular4 branch I get the error:
```
Module not found: Error: Can't resolve 'core-js/shim' in '/Users/Andrew/Projects/angular4-test/ClientApp'
     @ ./ClientApp/boot-server.ts 3:0-23
```
Others have reported the same problem (see #930). It appears that adding core-js to project.json fixes this problem--and that's all this PR does.