### PR TITLE
Outputs vs-2017.3.host.json file

### DIFF
--- a/templates/package-builder/src/build/build.ts
+++ b/templates/package-builder/src/build/build.ts
@@ -160,6 +160,14 @@ function buildDotNetNewNuGetPackage() {
         fs.writeFileSync(path.join(templateConfigDir, 'dotnetcli.host.json'), JSON.stringify({
             symbolInfo: {}
         }, null, 2));
+        
+        fs.writeFileSync(path.join(templateConfigDir, 'vs-2017.3.host.json'), JSON.stringify({
+            name: { text: templateConfig.displayName },
+            description: { text: templateConfig.displayName },
+            order: 2000,
+            learnMoreLink: "https://github.com/aspnet/JavaScriptServices",
+            uiFilters: [ "oneaspnet" ]
+        }, null, 2));
     });
 
     // Invoke NuGet to create the final package


### PR DESCRIPTION
This should now write out the correct file for VS to pick up. The icon is missing since I'm not totally sure about how we should inject that into the _.template.config_ folder. Also, is there a description of each template we can use?