### PR TITLE
Update boot-client.ts to handle IE 11 shim issues

### DIFF
--- a/templates/AngularSpa/ClientApp/boot-client.ts
+++ b/templates/AngularSpa/ClientApp/boot-client.ts
@@ -1,3 +1,4 @@
+import "core-js/client/shim";
 import 'reflect-metadata';
 import 'zone.js';
 import { enableProdMode } from '@angular/core';


### PR DESCRIPTION
In IE 11, when you get error like this:
Unable to get property 'apply' of undefined or null reference

In functions like this:
```
function combine(options) {
    return ((Object)).assign.apply(((Object)), [{}].concat(options));
}	
```

in the vendor.js file

This article tells you to use core-js because Angular already has a dependency on it:
http://stackoverflow.com/questions/41276692/angular2-ie11-unable-to-get-property-apply-of-undefined-or-null-reference

You add:
import "core-js/client/shim";

to the top of boot-client.ts

and the problem goes away. 

This issue may be related:
https://github.com/aspnet/JavaScriptServices/issues/926