### PR TITLE
API route mapping to get 404 instead of Home/Index

### DIFF
--- a/templates/AngularSpa/Startup.cs
+++ b/templates/AngularSpa/Startup.cs
@@ -57,10 +57,16 @@ namespace WebApplicationBasic
                 routes.MapRoute(
                     name: "default",
                     template: "{controller=Home}/{action=Index}/{id?}");
+            });
 
-                routes.MapSpaFallbackRoute(
-                    name: "spa-fallback",
-                    defaults: new { controller = "Home", action = "Index" });
+            app.MapWhen(x => !x.Request.Path.Value.StartsWith("/api"), builder =>
+            {
+                builder.UseMvc(routes =>
+                {
+                    routes.MapSpaFallbackRoute(
+                        name: "spa-fallback",
+                        defaults: new { controller = "Home", action = "Index" });
+                });
             });
         }
     }


### PR DESCRIPTION
Changed the route mapping so that calls to API methods that don't exist return 404 and not a page