### PR TITLE
Re-add bootstrap import

### DIFF
--- a/templates/AngularSpa/ClientApp/boot-client.ts
+++ b/templates/AngularSpa/ClientApp/boot-client.ts
@@ -3,6 +3,7 @@ import 'zone.js';
 import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { AppModule } from './app/app.module.client';
+import 'bootstrap';
 
 if (module['hot']) {
     module['hot'].accept();


### PR DESCRIPTION
In the update to Angular 4 ([PR #800](https://github.com/aspnet/JavaScriptServices/issues/800)), the bootstrap import got removed from boot.client.ts, causing the navbar-toggle menu to no longer work in the template.  Re-adding so navbar-toggle is functional again.