### PR TITLE
Unified way to report node invocation errors

### DIFF
--- a/src/Microsoft.AspNetCore.NodeServices/HostingModels/HttpNodeInstance.cs
+++ b/src/Microsoft.AspNetCore.NodeServices/HostingModels/HttpNodeInstance.cs
@@ -21,7 +21,6 @@ namespace Microsoft.AspNetCore.NodeServices.HostingModels
     /// <seealso cref="Microsoft.AspNetCore.NodeServices.HostingModels.OutOfProcessNodeInstance" />
     internal class HttpNodeInstance : OutOfProcessNodeInstance
     {
-        private readonly static int streamBufferSize = 16 * 1024;
         private static readonly Regex PortMessageRegex =
             new Regex(@"^\[Microsoft.AspNetCore.NodeServices.HttpNodeHost:Listening on port (\d+)\]$");
 
@@ -136,28 +135,6 @@ namespace Microsoft.AspNetCore.NodeServices.HostingModels
                 }
 
                 _disposed = true;
-            }
-        }
-
-        private static async Task<T> ReadJsonAsync<T>(Stream stream, CancellationToken cancellationToken)
-        {
-            var json = Encoding.UTF8.GetString(await ReadAllBytesAsync(stream, cancellationToken));
-            return JsonConvert.DeserializeObject<T>(json, jsonSerializerSettings);
-        }
-
-        private static async Task<byte[]> ReadAllBytesAsync(Stream input, CancellationToken cancellationToken)
-        {
-            byte[] buffer = new byte[streamBufferSize];
-
-            using (var ms = new MemoryStream())
-            {
-                int read;
-                while ((read = await input.ReadAsync(buffer, 0, buffer.Length, cancellationToken)) > 0)
-                {
-                    ms.Write(buffer, 0, read);
-                }
-
-                return ms.ToArray();
             }
         }
 

--- a/src/Microsoft.AspNetCore.NodeServices/HostingModels/HttpNodeInstance.cs
+++ b/src/Microsoft.AspNetCore.NodeServices/HostingModels/HttpNodeInstance.cs
@@ -21,6 +21,7 @@ namespace Microsoft.AspNetCore.NodeServices.HostingModels
     /// <seealso cref="Microsoft.AspNetCore.NodeServices.HostingModels.OutOfProcessNodeInstance" />
     internal class HttpNodeInstance : OutOfProcessNodeInstance
     {
+        private readonly static int streamBufferSize = 16 * 1024;
         private static readonly Regex PortMessageRegex =
             new Regex(@"^\[Microsoft.AspNetCore.NodeServices.HttpNodeHost:Listening on port (\d+)\]$");
 
@@ -66,8 +67,10 @@ namespace Microsoft.AspNetCore.NodeServices.HostingModels
             if (!response.IsSuccessStatusCode)
             {
                 // Unfortunately there's no true way to cancel ReadAsStringAsync calls, hence AbandonIfCancelled
-                var responseErrorString = await response.Content.ReadAsStringAsync().OrThrowOnCancellation(cancellationToken);
-                throw new Exception("Call to Node module failed with error: " + responseErrorString);
+                var responseJson = await response.Content.ReadAsStringAsync().OrThrowOnCancellation(cancellationToken);
+                var responseError = JsonConvert.DeserializeObject<RpcJsonResponse>(responseJson, jsonSerializerSettings);
+
+                throw new NodeInvocationException(responseError.ErrorMessage, responseError.ErrorDetails);
             }
 
             var responseContentType = response.Content.Headers.ContentType;
@@ -135,5 +138,35 @@ namespace Microsoft.AspNetCore.NodeServices.HostingModels
                 _disposed = true;
             }
         }
+
+        private static async Task<T> ReadJsonAsync<T>(Stream stream, CancellationToken cancellationToken)
+        {
+            var json = Encoding.UTF8.GetString(await ReadAllBytesAsync(stream, cancellationToken));
+            return JsonConvert.DeserializeObject<T>(json, jsonSerializerSettings);
+        }
+
+        private static async Task<byte[]> ReadAllBytesAsync(Stream input, CancellationToken cancellationToken)
+        {
+            byte[] buffer = new byte[streamBufferSize];
+
+            using (var ms = new MemoryStream())
+            {
+                int read;
+                while ((read = await input.ReadAsync(buffer, 0, buffer.Length, cancellationToken)) > 0)
+                {
+                    ms.Write(buffer, 0, read);
+                }
+
+                return ms.ToArray();
+            }
+        }
+
+#pragma warning disable 649 // These properties are populated via JSON deserialization
+        private class RpcJsonResponse
+        {
+            public string ErrorMessage { get; set; }
+            public string ErrorDetails { get; set; }
+        }
+#pragma warning restore 649
     }
 }

--- a/src/Microsoft.AspNetCore.NodeServices/TypeScript/HttpNodeInstanceEntryPoint.ts
+++ b/src/Microsoft.AspNetCore.NodeServices/TypeScript/HttpNodeInstanceEntryPoint.ts
@@ -86,5 +86,8 @@ function readRequestBodyAsJson(request, callback) {
 
 function respondWithError(res: http.ServerResponse, errorValue: any) {
     res.statusCode = 500;
-    res.end(errorValue.stack || errorValue.toString());
+    res.end(JSON.stringify({
+        errorMessage: errorValue.message || errorValue,
+        errorDetails: errorValue.stack || null
+    }));
 }


### PR DESCRIPTION
There is the different way how node invocation errors are reported when using `HttpNodeInstance` and `SocketNodeInstance`. This PR unify the way how such errors are reported and lets create middleware that to handle `NodeInvocationException` and display dedicated error page for node errors #988 