### PR TITLE
newer version react-router 4.0.12 breaks - ugly force version 4.0.11 #1066

### DIFF
--- a/templates/ReactReduxSpa/package.json
+++ b/templates/ReactReduxSpa/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "dependencies": {
+    "@types/react-router": "4.0.11",
     "@types/history": "4.5.1",
     "@types/react": "15.0.29",
     "@types/react-dom": "15.5.0",


### PR DESCRIPTION
Newer version of react-router 4.0.12 breaks typescript compilation of template reactredux  Probably needs some better fix but this is a workaround.