### PR TITLE
Fix webpack HMR proxying logic for apps running on non-root URLs (e.g., full IIS virtual directories)

### DIFF
--- a/src/Microsoft.AspNetCore.SpaServices/Webpack/ConditionalProxyMiddleware.cs
+++ b/src/Microsoft.AspNetCore.SpaServices/Webpack/ConditionalProxyMiddleware.cs
@@ -28,6 +28,11 @@ namespace Microsoft.AspNetCore.SpaServices.Webpack
             string pathPrefix,
             ConditionalProxyMiddlewareOptions options)
         {
+            if (!pathPrefix.StartsWith("/"))
+            {
+                pathPrefix = "/" + pathPrefix;
+            }
+
             _next = next;
             _pathPrefix = pathPrefix;
             _options = options;
@@ -65,7 +70,7 @@ namespace Microsoft.AspNetCore.SpaServices.Webpack
 
             requestMessage.Headers.Host = _options.Host + ":" + _options.Port;
             var uriString =
-                $"{_options.Scheme}://{_options.Host}:{_options.Port}{context.Request.PathBase}{context.Request.Path}{context.Request.QueryString}";
+                $"{_options.Scheme}://{_options.Host}:{_options.Port}{context.Request.Path}{context.Request.QueryString}";
             requestMessage.RequestUri = new Uri(uriString);
             requestMessage.Method = new HttpMethod(context.Request.Method);
 

--- a/src/Microsoft.AspNetCore.SpaServices/Webpack/WebpackDevMiddleware.cs
+++ b/src/Microsoft.AspNetCore.SpaServices/Webpack/WebpackDevMiddleware.cs
@@ -101,9 +101,9 @@ namespace Microsoft.AspNetCore.Builder
             // plus /__webpack_hmr is proxied with infinite timeout, because it's an EventSource (long-lived request).
             foreach (var publicPath in devServerInfo.PublicPaths)
             {
+                appBuilder.UseProxyToLocalWebpackDevMiddleware(publicPath + hmrEndpoint, devServerInfo.Port, Timeout.InfiniteTimeSpan);
                 appBuilder.UseProxyToLocalWebpackDevMiddleware(publicPath, devServerInfo.Port, TimeSpan.FromSeconds(100));
             }
-            appBuilder.UseProxyToLocalWebpackDevMiddleware(hmrEndpoint, devServerInfo.Port, Timeout.InfiniteTimeSpan);
         }
 
         private static void UseProxyToLocalWebpackDevMiddleware(this IApplicationBuilder appBuilder, string publicPath, int proxyToPort, TimeSpan requestTimeout)


### PR DESCRIPTION
Previously the proxying logic handled nonempty `PathBase` values incorrectly. Also it didn't allow for Webpack `publicPath` values being set dynamically at runtime via `<base href>`. Both of these are needed for HMR to work correctly if the app is hosted in a virtual directory.

This change, along with an update to the `aspnet-webpack` NPM package, will fix #488