### PR TITLE
Added npm Install on first-run

### DIFF
--- a/templates/AngularSpa/AngularSpa.csproj
+++ b/templates/AngularSpa/AngularSpa.csproj
@@ -38,6 +38,7 @@
     <!-- In development, the dist files won't exist on the first run or when cloning to
          a different machine, so rebuild them if not already present. -->
     <Message Importance="high" Text="Performing first-run Webpack build..." />
+    <Exec Command="npm install" />
     <Exec Command="node node_modules/webpack/bin/webpack.js --config webpack.config.vendor.js" />
     <Exec Command="node node_modules/webpack/bin/webpack.js" />
   </Target>


### PR DESCRIPTION
on my build agent the build failed because npm install was not running bevor the build. I can not see why npm install should only run when publishing.