### PR TITLE
shrinkwrap error with peerDependencies wp version

### DIFF
--- a/src/Microsoft.AspNetCore.SpaServices/npm/aspnet-webpack/package.json
+++ b/src/Microsoft.AspNetCore.SpaServices/npm/aspnet-webpack/package.json
@@ -33,6 +33,6 @@
     "webpack": "^1.13.2"
   },
   "peerDependencies": {
-    "webpack": "^1.13.2 || ^2.1.0-beta"
+    "webpack": "^1.13.2 || ^2.1.0-beta || ^3.3.0"
   }
 }


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)
 - Add peer dependency for webpack: "^3.3.0", fix  npm shrinkwrap problem  with newer webpack version