### PR TITLE
fix(webpack): fix middleware to specifically serialize options as pascal case

### DIFF
--- a/src/Microsoft.AspNetCore.SpaServices/Webpack/WebpackDevMiddleware.cs
+++ b/src/Microsoft.AspNetCore.SpaServices/Webpack/WebpackDevMiddleware.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using Microsoft.AspNetCore.NodeServices;
 using Microsoft.AspNetCore.SpaServices.Webpack;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 
 namespace Microsoft.AspNetCore.Builder
 {
@@ -87,7 +88,7 @@ namespace Microsoft.AspNetCore.Builder
             };
             var devServerInfo =
                 nodeServices.InvokeExportAsync<WebpackDevServerInfo>(nodeScript.FileName, "createWebpackDevServer",
-                    JsonConvert.SerializeObject(devServerOptions)).Result;
+                    JsonConvert.SerializeObject(devServerOptions, new JsonSerializerSettings() { ContractResolver = new DefaultContractResolver() })).Result;
 
             // If we're talking to an older version of aspnet-webpack, it will return only a single PublicPath,
             // not an array of PublicPaths. Handle that scenario.


### PR DESCRIPTION
This fixes middleware when consumers override serializer defaults settings via `JsonConvert.DefaultSettings` which would break webpack options passed to node. 

Since it's expected to be as Pascal case, it's safer to specifically specify it, and in our case we had it default to camelCase which was silently breaking it (and it was quite hard to figure it out).
