### PR TITLE
HttpNodeInstance - Added Timeout to HttpClient to always be longer than the InvocationTimeoutMilliseconds

### DIFF
--- a/src/Microsoft.AspNetCore.NodeServices/HostingModels/HttpNodeInstance.cs
+++ b/src/Microsoft.AspNetCore.NodeServices/HostingModels/HttpNodeInstance.cs
@@ -50,6 +50,7 @@ namespace Microsoft.AspNetCore.NodeServices.HostingModels
                 options.DebuggingPort)
         {
             _client = new HttpClient();
+            _client.Timeout = TimeSpan.FromMilliseconds(options.InvocationTimeoutMilliseconds + 1000);
         }
 
         private static string MakeCommandLineOptions(int port)


### PR DESCRIPTION
HttpClient defaults to 100 seconds. If InvocationTimeoutMilliseconds is greater than the default of the HttpClient, the task will fail with a Task was canceled exception.