### PR TITLE
Allow lazy loading with AngularSpa in dev build

### DIFF
--- a/templates/AngularSpa/package.json
+++ b/templates/AngularSpa/package.json
@@ -19,6 +19,7 @@
     "@angular/router": "4.2.5",
     "@ngtools/webpack": "1.5.0",
     "@types/webpack-env": "1.13.0",
+    "angular2-router-loader": "0.3.5",
     "angular2-template-loader": "0.6.2",
     "aspnet-prerendering": "^3.0.1",
     "aspnet-webpack": "^2.0.1",

--- a/templates/AngularSpa/webpack.config.js
+++ b/templates/AngularSpa/webpack.config.js
@@ -17,7 +17,7 @@ module.exports = (env) => {
         },
         module: {
             rules: [
-                { test: /\.ts$/, include: /ClientApp/, use: isDevBuild ? ['awesome-typescript-loader?silent=true', 'angular2-template-loader'] : '@ngtools/webpack' },
+                { test: /\.ts$/, include: /ClientApp/, use: isDevBuild ? ['awesome-typescript-loader?silent=true', 'angular2-template-loader', 'angular2-router-loader'] : '@ngtools/webpack' },
                 { test: /\.html$/, use: 'html-loader?minimize=false' },
                 { test: /\.css$/, use: [ 'to-string-loader', isDevBuild ? 'css-loader' : 'css-loader?minimize' ] },
                 { test: /\.(png|jpg|jpeg|gif|svg)$/, use: 'url-loader?limit=25000' }


### PR DESCRIPTION
Previously, the AngularSpa didn't include `angular2-router-loader`.
This commit ensures it does.

This closes #1194