### PR TITLE
redux template: automatically infer FetchData's new props type

### DIFF
--- a/templates/Microsoft.DotNet.Web.Spa.ProjectTemplates/redux/ClientApp/components/FetchData.tsx
+++ b/templates/Microsoft.DotNet.Web.Spa.ProjectTemplates/redux/ClientApp/components/FetchData.tsx
@@ -70,4 +70,4 @@ class FetchData extends React.Component<WeatherForecastProps, {}> {
 export default connect(
     (state: ApplicationState) => state.weatherForecasts, // Selects which state properties are merged into the component's props
     WeatherForecastsState.actionCreators                 // Selects which action creators are merged into the component's props
-)(FetchData) as typeof FetchData;
+)(FetchData);


### PR DESCRIPTION
After being connected to redux's store the props type isn't the same anymore since `WeatherForecastsState` gets filled by the store.

The template worked because when using the `FetchData` component within the `Route` component it seems like its type doesn't get checked accurately. However using the component as `<FetchData ... />` generates an error since the properties of `WeatherForecastsState` were seemingly missing.

The type definition of redux's `connect` has been built in such a way, that the new props type gets automatically infered.