### PR TITLE
Allow webpack configs to be authored in typescript (fixes #1241)

### DIFF
--- a/src/Microsoft.AspNetCore.SpaServices/Webpack/WebpackDevMiddleware.cs
+++ b/src/Microsoft.AspNetCore.SpaServices/Webpack/WebpackDevMiddleware.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNetCore.Builder
     /// </summary>
     public static class WebpackDevMiddleware
     {
-        private const string DefaultConfigFile = "webpack.config.js";
+        private const string DefaultConfigFileNoExtension = "webpack.config";
 
         private static readonly JsonSerializerSettings jsonSerializerSettings = new JsonSerializerSettings
         {
@@ -87,10 +87,14 @@ namespace Microsoft.AspNetCore.Builder
                 ? options.HotModuleReplacementEndpoint
                 : "/__webpack_hmr"; // Matches webpack's built-in default
 
+            var defaultConfigFileExtension = options.UseTypeScriptConfig ? "ts" : "js";
+            var defaultConfigFile = $"{DefaultConfigFileNoExtension}.{defaultConfigFileExtension}";
+
             // Tell Node to start the server hosting webpack-dev-middleware
             var devServerOptions = new
             {
-                webpackConfigPath = Path.Combine(nodeServicesOptions.ProjectPath, options.ConfigFile ?? DefaultConfigFile),
+                webpackConfigPath = Path.Combine(nodeServicesOptions.ProjectPath, options.ConfigFile ?? defaultConfigFile),
+                useTypeScriptConfig = options.UseTypeScriptConfig,
                 suppliedOptions = options,
                 understandsMultiplePublicPaths = true,
                 hotModuleReplacementEndpointUrl = hmrEndpoint

--- a/src/Microsoft.AspNetCore.SpaServices/Webpack/WebpackDevMiddlewareOptions.cs
+++ b/src/Microsoft.AspNetCore.SpaServices/Webpack/WebpackDevMiddlewareOptions.cs
@@ -36,9 +36,14 @@ namespace Microsoft.AspNetCore.SpaServices.Webpack
         public IDictionary<string, string> HotModuleReplacementClientOptions { get; set; } 
 
         /// <summary>
-        /// Specifies the Webpack configuration file to be used. If not set, defaults to 'webpack.config.js'.
+        /// Specifies the Webpack configuration file to be used. If not set, defaults to 'webpack.config.(js|ts) dependent upon UseTypeScriptConfig option'.
         /// </summary>
         public string ConfigFile { get; set; }
+
+        /// <summary>
+        /// Specifies the Webpack configuration is written in typescript and must be transpiled.
+        /// </summary>
+        public bool UseTypeScriptConfig { get; set; }
 
         /// <summary>
         /// The root path of your project. Webpack runs in this context.

--- a/src/Microsoft.AspNetCore.SpaServices/npm/aspnet-webpack/src/WebpackDevMiddleware.ts
+++ b/src/Microsoft.AspNetCore.SpaServices/npm/aspnet-webpack/src/WebpackDevMiddleware.ts
@@ -19,6 +19,7 @@ export interface CreateDevServerCallback {
 // These are the options passed by WebpackDevMiddleware.cs
 interface CreateDevServerOptions {
     webpackConfigPath: string;
+    useTypeScriptConfig: boolean;
     suppliedOptions: DevServerOptions;
     hotModuleReplacementEndpointUrl: string;
 }
@@ -234,6 +235,10 @@ export function createWebpackDevServer(callback: CreateDevServerCallback, option
             PublicPaths: []
         });
         return;
+    }
+
+    if (options.useTypeScriptConfig) {
+      require('ts-node/register');
     }
 
     // Read the webpack config's export, and normalize it into the more general 'array of configs' format


### PR DESCRIPTION
@SteveSandersonMS good to make your acquaintance again (a nod from my KnockoutJS days, although you won't remember me)

This fix is entirely untested and simply [following your instructions](https://github.com/aspnet/JavaScriptServices/issues/1241#issuecomment-327486989) so we can get the ball rolling. Is this really all that's needed for the typescript to get parsed on demand??

```diff
+    if (options.useTypescriptConfig) {
+      require('ts-node/register');
+    }
+
```

I'll try and see if I can build the solution, replace the DLL and node_modules in my project and confirm the fix. 