### PR TITLE
Added a more updated alternative to isomorphic-fetch.

### DIFF
--- a/src/Microsoft.AspNetCore.SpaServices/npm/domain-task/package.json
+++ b/src/Microsoft.AspNetCore.SpaServices/npm/domain-task/package.json
@@ -17,9 +17,9 @@
     "url": "https://github.com/aspnet/JavaScriptServices.git"
   },
   "dependencies": {
+    "cross-fetch": "^1.1.0",
     "domain-context": "^0.5.1",
-    "is-absolute-url": "^2.1.0",
-    "isomorphic-fetch": "^2.2.1"
+    "is-absolute-url": "^2.1.0"
   },
   "devDependencies": {
     "@types/node": "^6.0.42",

--- a/src/Microsoft.AspNetCore.SpaServices/npm/domain-task/src/fetch.ts
+++ b/src/Microsoft.AspNetCore.SpaServices/npm/domain-task/src/fetch.ts
@@ -3,7 +3,7 @@ import * as domain from 'domain';
 import * as domainContext from 'domain-context';
 import * as isAbsoluteUrl from 'is-absolute-url';
 import { baseUrl } from './main';
-const isomorphicFetch = require('isomorphic-fetch');
+const crossFetch = require('cross-fetch');
 const isNode = typeof process === 'object' && process.versions && !!process.versions.node;
 const nodeHttps = isNode && require('https');
 const isHttpsRegex = /^https\:/;
@@ -32,7 +32,7 @@ function issueRequest(baseUrl: string, req: string | Request, init?: RequestInit
     }
 
     init = applyHttpsAgentPolicy(init, isRelativeUrl, baseUrl);
-    return isomorphicFetch(req, init);
+    return crossFetch(req, init);
 }
 
 function applyHttpsAgentPolicy(init: RequestInit, isRelativeUrl: boolean, baseUrl: string): RequestInit {


### PR DESCRIPTION
isomorphic-fetch hasn't been updated for a while, so cross-fetch was created in order to provide a more updated, flexible and [fixed](https://github.com/matthew-andrews/isomorphic-fetch/issues/125) alternative to the community.
