### PR TITLE
Update appveyor to run korebuild

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,19 +1,21 @@
-﻿init:
+init:
   - git config --global core.autocrlf true
 install:
-   - ps: Install-Product node 6.9.2 x64
-   # .NET Core SDK binaries
-   # Download .NET Core 2.0 Preview 3 SDK and add to PATH
-   - ps: $urlCurrent = "https://dotnetcli.azureedge.net/dotnet/Sdk/2.0.0-preview3-006857/dotnet-sdk-2.0.0-preview3-006857-win-x64.zip"
-   - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnetsdk"
-   - ps: mkdir $env:DOTNET_INSTALL_DIR -Force | Out-Null
-   - ps: $tempFileCurrent = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
-   - ps: (New-Object System.Net.WebClient).DownloadFile($urlCurrent, $tempFileCurrent)
-   - ps: Add-Type -AssemblyName System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::ExtractToDirectory($tempFileCurrent, $env:DOTNET_INSTALL_DIR)
-   - ps: $env:Path = "$env:DOTNET_INSTALL_DIR;$env:Path"
+  - ps: Install-Product node 6.9.2 x64
+branches:
+  only:
+    - master
+    - release
+    - dev
+    - /^(.*\/)?ci-.*$/
+    - /^rel\/.*/
+build_script:
+  - ps: .\run.ps1 default-build
 clone_depth: 1
 environment:
   global:
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     DOTNET_CLI_TELEMETRY_OPTOUT: 1
+test: off
 deploy: off
+os: Visual Studio 2017

--- a/korebuild.json
+++ b/korebuild.json
@@ -1,4 +1,10 @@
 {
   "$schema": "https://raw.githubusercontent.com/aspnet/BuildTools/dev/tools/korebuild.schema.json",
-  "channel": "dev"
+  "channel": "dev",
+  "toolsets": {
+    "nodejs": {
+      "required": true,
+      "minVersion": "6.9"
+    }
+  }
 }


### PR DESCRIPTION
AppVeyor isn't actually building the repo because the default AppVeyor image is VS 2015, not 2017. 

Changes:
 - update appveyor to vs2017
 - execute a default build with korebuild
 - add 'nodejs' as a required toolset in korebuild.json. This ensures nodejs is available on the machine. (Assuming this is required so tests can run)