### PR TITLE
Update peerDependency to support webpack 3

### DIFF
--- a/src/Microsoft.AspNetCore.SpaServices/npm/aspnet-webpack-react/package.json
+++ b/src/Microsoft.AspNetCore.SpaServices/npm/aspnet-webpack-react/package.json
@@ -23,6 +23,6 @@
     "webpack": "^2.2.0"
   },
   "peerDependencies": {
-    "webpack": "^2.2.0"
+    "webpack": "^2.2.0 || ^3.0.0"
   }
 }


### PR DESCRIPTION
Update peerDependency to support webpack 3.
- This is only to remove the npm peer dep warning.
- Reports of various people already running 3.x are listed in.

Addresses #1361