### PR TITLE
Correcting timeout message to handle the case where timeout is set to >= 60s

### DIFF
--- a/src/Microsoft.AspNetCore.SpaServices.Extensions/AngularCli/AngularCliMiddleware.cs
+++ b/src/Microsoft.AspNetCore.SpaServices.Extensions/AngularCli/AngularCliMiddleware.cs
@@ -56,7 +56,7 @@ namespace Microsoft.AspNetCore.SpaServices.AngularCli
                 var timeout = spaBuilder.Options.StartupTimeout;
                 return targetUriTask.WithTimeout(timeout,
                     $"The Angular CLI process did not start listening for requests " +
-                    $"within the timeout period of {timeout.Seconds} seconds. " +
+                    $"within the timeout period of {timeout.TotalSeconds} seconds. " +
                     $"Check the log output for error information.");
             });
         }

--- a/src/Microsoft.AspNetCore.SpaServices.Extensions/Prerendering/SpaPrerenderingExtensions.cs
+++ b/src/Microsoft.AspNetCore.SpaServices.Extensions/Prerendering/SpaPrerenderingExtensions.cs
@@ -94,7 +94,7 @@ namespace Microsoft.AspNetCore.Builder
                     // underlying build task so that subsequent requests could still work.
                     await buildOnDemandTask.WithTimeout(buildTimeout,
                         $"The prerendering build process did not complete within the " +
-                        $"timeout period of {buildTimeout.Seconds} seconds. " +
+                        $"timeout period of {buildTimeout.TotalSeconds} seconds. " +
                         $"Check the log output for error information.");
                 }
 

--- a/src/Microsoft.AspNetCore.SpaServices.Extensions/ReactDevelopmentServer/ReactDevelopmentServerMiddleware.cs
+++ b/src/Microsoft.AspNetCore.SpaServices.Extensions/ReactDevelopmentServer/ReactDevelopmentServerMiddleware.cs
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer
                 var timeout = spaBuilder.Options.StartupTimeout;
                 return targetUriTask.WithTimeout(timeout,
                     $"The create-react-app server did not start listening for requests " +
-                    $"within the timeout period of {timeout.Seconds} seconds. " +
+                    $"within the timeout period of {timeout.TotalSeconds} seconds. " +
                     $"Check the log output for error information.");
             });
         }


### PR DESCRIPTION
Use TimeSpan.TotalSeconds instead of TimeSpan.Seconds in timeout messages.

This resolves #1614 