### PR TITLE
StreamReader doesn't send last line's contents to listener

### DIFF
--- a/src/Microsoft.AspNetCore.SpaServices.Extensions/Util/EventedStreamReader.cs
+++ b/src/Microsoft.AspNetCore.SpaServices.Extensions/Util/EventedStreamReader.cs
@@ -83,6 +83,11 @@ namespace Microsoft.AspNetCore.NodeServices.Util
                 var chunkLength = await _streamReader.ReadAsync(buf, 0, buf.Length);
                 if (chunkLength == 0)
                 {
+                    if (_linesBuffer.Length > 0)
+                    {
+                        OnCompleteLine(_linesBuffer.ToString());
+                        _linesBuffer.Clear();
+                    }
                     OnClosed();
                     break;
                 }


### PR DESCRIPTION
Fixes https://github.com/aspnet/JavaScriptServices/issues/1619

Issue causes AngularCliBuilder to not know when build:ssr is complete. Specifically affecting Angular 6