### PR TITLE
Expose Node.js Options

### DIFF
--- a/src/Microsoft.AspNetCore.NodeServices.Sockets/SocketNodeInstance.cs
+++ b/src/Microsoft.AspNetCore.NodeServices.Sockets/SocketNodeInstance.cs
@@ -47,13 +47,14 @@ namespace Microsoft.AspNetCore.NodeServices.Sockets
                     "/Content/Node/entrypoint-socket.js"),
                 options.ProjectPath,
                 options.WatchFileExtensions,
-                MakeNewCommandLineOptions(socketAddress),
+                MakeSocketAddressArgument(socketAddress),
                 options.ApplicationStoppingToken,
                 options.NodeInstanceOutputLogger,
                 options.EnvironmentVariables,
                 options.InvocationTimeoutMilliseconds,
                 options.LaunchWithDebugging,
-                options.DebuggingPort)
+                options.DebuggingPort,
+                options.NodeOptions)
         {
             _socketAddress = socketAddress;
         }
@@ -212,7 +213,7 @@ namespace Microsoft.AspNetCore.NodeServices.Sockets
             }
         }
 
-        private static string MakeNewCommandLineOptions(string listenAddress)
+        private static string MakeSocketAddressArgument(string listenAddress)
         {
             return $"--listenAddress {listenAddress}";
         }

--- a/src/Microsoft.AspNetCore.NodeServices/Configuration/NodeServicesOptions.cs
+++ b/src/Microsoft.AspNetCore.NodeServices/Configuration/NodeServicesOptions.cs
@@ -110,5 +110,10 @@ namespace Microsoft.AspNetCore.NodeServices
         /// A token that indicates when the host application is stopping.
         /// </summary>
         public CancellationToken ApplicationStoppingToken { get; set; }
+
+        /// <summary>
+        /// Node.js command line options, e.g "--inspect-brk".
+        /// </summary>
+        public string NodeOptions { get; set; }
     }
 }

--- a/src/Microsoft.AspNetCore.NodeServices/HostingModels/HttpNodeInstance.cs
+++ b/src/Microsoft.AspNetCore.NodeServices/HostingModels/HttpNodeInstance.cs
@@ -41,19 +41,20 @@ namespace Microsoft.AspNetCore.NodeServices.HostingModels
                     "/Content/Node/entrypoint-http.js"),
                 options.ProjectPath,
                 options.WatchFileExtensions,
-                MakeCommandLineOptions(port),
+                MakePortArgument(port),
                 options.ApplicationStoppingToken,
                 options.NodeInstanceOutputLogger,
                 options.EnvironmentVariables,
                 options.InvocationTimeoutMilliseconds,
                 options.LaunchWithDebugging,
-                options.DebuggingPort)
+                options.DebuggingPort,
+                options.NodeOptions)
         {
             _client = new HttpClient();
             _client.Timeout = TimeSpan.FromMilliseconds(options.InvocationTimeoutMilliseconds + 1000);
         }
 
-        private static string MakeCommandLineOptions(int port)
+        private static string MakePortArgument(int port)
         {
             return $"--port {port}";
         }

--- a/src/Microsoft.AspNetCore.NodeServices/HostingModels/OutOfProcessNodeInstance.cs
+++ b/src/Microsoft.AspNetCore.NodeServices/HostingModels/OutOfProcessNodeInstance.cs
@@ -44,24 +44,26 @@ namespace Microsoft.AspNetCore.NodeServices.HostingModels
         /// <param name="entryPointScript">The path to the entry point script that the Node instance should load and execute.</param>
         /// <param name="projectPath">The root path of the current project. This is used when resolving Node.js module paths relative to the project root.</param>
         /// <param name="watchFileExtensions">The filename extensions that should be watched within the project root. The Node instance will automatically shut itself down if any matching file changes.</param>
-        /// <param name="commandLineArguments">Additional command-line arguments to be passed to the Node.js instance.</param>
+        /// <param name="scriptArguments">Command-line arguments to be passed to the Node.js entry script (see HttpNodeInstanceEntryPoints.ts).</param>
         /// <param name="applicationStoppingToken">A token that indicates when the host application is stopping.</param>
         /// <param name="nodeOutputLogger">The <see cref="ILogger"/> to which the Node.js instance's stdout/stderr (and other log information) should be written.</param>
         /// <param name="environmentVars">Environment variables to be set on the Node.js process.</param>
         /// <param name="invocationTimeoutMilliseconds">The maximum duration, in milliseconds, to wait for RPC calls to complete.</param>
         /// <param name="launchWithDebugging">If true, passes a flag to the Node.js process telling it to accept V8 debugger connections.</param>
         /// <param name="debuggingPort">If debugging is enabled, the Node.js process should listen for V8 debugger connections on this port.</param>
+        /// <param name="nodeOptions">Command-line options to be passed to the Node.js instance (see https://nodejs.org/api/cli.html#cli_options).</param>
         public OutOfProcessNodeInstance(
             string entryPointScript,
             string projectPath,
             string[] watchFileExtensions,
-            string commandLineArguments,
+            string scriptArguments,
             CancellationToken applicationStoppingToken,
             ILogger nodeOutputLogger,
             IDictionary<string, string> environmentVars,
             int invocationTimeoutMilliseconds,
             bool launchWithDebugging,
-            int debuggingPort)
+            int debuggingPort,
+            string nodeOptions = null)
         {
             if (nodeOutputLogger == null)
             {
@@ -73,8 +75,8 @@ namespace Microsoft.AspNetCore.NodeServices.HostingModels
             _invocationTimeoutMilliseconds = invocationTimeoutMilliseconds;
             _launchWithDebugging = launchWithDebugging;
 
-            var startInfo = PrepareNodeProcessStartInfo(_entryPointScript.FileName, projectPath, commandLineArguments,
-                environmentVars, _launchWithDebugging, debuggingPort);
+            var startInfo = PrepareNodeProcessStartInfo(_entryPointScript.FileName, projectPath, scriptArguments,
+                environmentVars, _launchWithDebugging, debuggingPort, nodeOptions);
             _nodeProcess = LaunchNodeProcess(startInfo);
             _watchFileExtensions = watchFileExtensions;
             _fileSystemWatcher = BeginFileWatcher(projectPath);
@@ -205,31 +207,34 @@ namespace Microsoft.AspNetCore.NodeServices.HostingModels
         /// </summary>
         /// <param name="entryPointFilename">The entrypoint JavaScript file that the Node.js process should execute.</param>
         /// <param name="projectPath">The root path of the project. This is used when locating Node.js modules relative to the project root.</param>
-        /// <param name="commandLineArguments">Command-line arguments to be passed to the Node.js process.</param>
+        /// <param name="scriptArguments"></param>
         /// <param name="environmentVars">Environment variables to be set on the Node.js process.</param>
         /// <param name="launchWithDebugging">If true, passes a flag to the Node.js process telling it to accept V8 Inspector connections.</param>
         /// <param name="debuggingPort">If debugging is enabled, the Node.js process should listen for V8 Inspector connections on this port.</param>
+        /// <param name="nodeOptions">Command-line arguments to be passed to the Node.js process.</param>
         /// <returns></returns>
         protected virtual ProcessStartInfo PrepareNodeProcessStartInfo(
-            string entryPointFilename, string projectPath, string commandLineArguments,
-            IDictionary<string, string> environmentVars, bool launchWithDebugging, int debuggingPort)
+            string entryPointFilename, string projectPath, string scriptArguments,
+            IDictionary<string, string> environmentVars, bool launchWithDebugging, int debuggingPort, string nodeOptions = null)
         {
             // This method is virtual, as it provides a way to override the NODE_PATH or the path to node.exe
-            string debuggingArgs;
+            string nodeDebuggingOptions;
             if (launchWithDebugging)
             {
-                debuggingArgs = debuggingPort != default(int) ? $"--inspect={debuggingPort} " : "--inspect ";
+                nodeDebuggingOptions = debuggingPort != default(int) ? $"--inspect={debuggingPort} " : "--inspect ";
                 _nodeDebuggingPort = debuggingPort;
             }
             else
             {
-                debuggingArgs = string.Empty;
+                nodeDebuggingOptions = string.Empty;
             }
 
             var thisProcessPid = Process.GetCurrentProcess().Id;
+
             var startInfo = new ProcessStartInfo("node")
             {
-                Arguments = $"{debuggingArgs}\"{entryPointFilename}\" --parentPid {thisProcessPid} {commandLineArguments ?? string.Empty}",
+                // Syntactically consistent with the syntax specified in the Node.js documentation: "node [options] [V8 options] [script.js | -e "script" | -] [--] [arguments]" (see https://nodejs.org/api/cli.html#cli_synopsis).
+                Arguments = $"{nodeDebuggingOptions} {nodeOptions ?? string.Empty} \"{entryPointFilename}\" -- --parentPid {thisProcessPid} {scriptArguments ?? string.Empty}",
                 UseShellExecute = false,
                 RedirectStandardInput = true,
                 RedirectStandardOutput = true,

--- a/src/Microsoft.AspNetCore.NodeServices/HostingModels/OutOfProcessNodeInstance.cs
+++ b/src/Microsoft.AspNetCore.NodeServices/HostingModels/OutOfProcessNodeInstance.cs
@@ -207,7 +207,7 @@ namespace Microsoft.AspNetCore.NodeServices.HostingModels
         /// </summary>
         /// <param name="entryPointFilename">The entrypoint JavaScript file that the Node.js process should execute.</param>
         /// <param name="projectPath">The root path of the project. This is used when locating Node.js modules relative to the project root.</param>
-        /// <param name="scriptArguments"></param>
+        /// <param name="scriptArguments">Command-line arguments to be passed to the Node.js entry script (see HttpNodeInstanceEntryPoints.ts).</param>
         /// <param name="environmentVars">Environment variables to be set on the Node.js process.</param>
         /// <param name="launchWithDebugging">If true, passes a flag to the Node.js process telling it to accept V8 Inspector connections.</param>
         /// <param name="debuggingPort">If debugging is enabled, the Node.js process should listen for V8 Inspector connections on this port.</param>

--- a/src/Microsoft.AspNetCore.NodeServices/HostingModels/OutOfProcessNodeInstance.cs
+++ b/src/Microsoft.AspNetCore.NodeServices/HostingModels/OutOfProcessNodeInstance.cs
@@ -44,7 +44,35 @@ namespace Microsoft.AspNetCore.NodeServices.HostingModels
         /// <param name="entryPointScript">The path to the entry point script that the Node instance should load and execute.</param>
         /// <param name="projectPath">The root path of the current project. This is used when resolving Node.js module paths relative to the project root.</param>
         /// <param name="watchFileExtensions">The filename extensions that should be watched within the project root. The Node instance will automatically shut itself down if any matching file changes.</param>
-        /// <param name="scriptArguments">Command-line arguments to be passed to the Node.js entry script (see HttpNodeInstanceEntryPoints.ts).</param>
+        /// <param name="commandLineArguments">Command-line arguments to be passed to the Node.js entry script (see HttpNodeInstanceEntryPoints.ts).</param>
+        /// <param name="applicationStoppingToken">A token that indicates when the host application is stopping.</param>
+        /// <param name="nodeOutputLogger">The <see cref="ILogger"/> to which the Node.js instance's stdout/stderr (and other log information) should be written.</param>
+        /// <param name="environmentVars">Environment variables to be set on the Node.js process.</param>
+        /// <param name="invocationTimeoutMilliseconds">The maximum duration, in milliseconds, to wait for RPC calls to complete.</param>
+        /// <param name="launchWithDebugging">If true, passes a flag to the Node.js process telling it to accept V8 debugger connections.</param>
+        /// <param name="debuggingPort">If debugging is enabled, the Node.js process should listen for V8 debugger connections on this port.</param>
+        public OutOfProcessNodeInstance(
+            string entryPointScript,
+            string projectPath,
+            string[] watchFileExtensions,
+            string commandLineArguments,
+            CancellationToken applicationStoppingToken,
+            ILogger nodeOutputLogger,
+            IDictionary<string, string> environmentVars,
+            int invocationTimeoutMilliseconds,
+            bool launchWithDebugging,
+            int debuggingPort) : 
+            this(entryPointScript, projectPath, watchFileExtensions, commandLineArguments, applicationStoppingToken, nodeOutputLogger, environmentVars, invocationTimeoutMilliseconds, launchWithDebugging, debuggingPort, null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="OutOfProcessNodeInstance"/>.
+        /// </summary>
+        /// <param name="entryPointScript">The path to the entry point script that the Node instance should load and execute.</param>
+        /// <param name="projectPath">The root path of the current project. This is used when resolving Node.js module paths relative to the project root.</param>
+        /// <param name="watchFileExtensions">The filename extensions that should be watched within the project root. The Node instance will automatically shut itself down if any matching file changes.</param>
+        /// <param name="commandLineArguments">Command-line arguments to be passed to the Node.js entry script (see HttpNodeInstanceEntryPoints.ts).</param>
         /// <param name="applicationStoppingToken">A token that indicates when the host application is stopping.</param>
         /// <param name="nodeOutputLogger">The <see cref="ILogger"/> to which the Node.js instance's stdout/stderr (and other log information) should be written.</param>
         /// <param name="environmentVars">Environment variables to be set on the Node.js process.</param>
@@ -56,14 +84,14 @@ namespace Microsoft.AspNetCore.NodeServices.HostingModels
             string entryPointScript,
             string projectPath,
             string[] watchFileExtensions,
-            string scriptArguments,
+            string commandLineArguments,
             CancellationToken applicationStoppingToken,
             ILogger nodeOutputLogger,
             IDictionary<string, string> environmentVars,
             int invocationTimeoutMilliseconds,
             bool launchWithDebugging,
             int debuggingPort,
-            string nodeOptions = null)
+            string nodeOptions)
         {
             if (nodeOutputLogger == null)
             {
@@ -75,7 +103,7 @@ namespace Microsoft.AspNetCore.NodeServices.HostingModels
             _invocationTimeoutMilliseconds = invocationTimeoutMilliseconds;
             _launchWithDebugging = launchWithDebugging;
 
-            var startInfo = PrepareNodeProcessStartInfo(_entryPointScript.FileName, projectPath, scriptArguments,
+            var startInfo = PrepareNodeProcessStartInfo(_entryPointScript.FileName, projectPath, commandLineArguments,
                 environmentVars, _launchWithDebugging, debuggingPort, nodeOptions);
             _nodeProcess = LaunchNodeProcess(startInfo);
             _watchFileExtensions = watchFileExtensions;
@@ -207,15 +235,32 @@ namespace Microsoft.AspNetCore.NodeServices.HostingModels
         /// </summary>
         /// <param name="entryPointFilename">The entrypoint JavaScript file that the Node.js process should execute.</param>
         /// <param name="projectPath">The root path of the project. This is used when locating Node.js modules relative to the project root.</param>
-        /// <param name="scriptArguments">Command-line arguments to be passed to the Node.js entry script (see HttpNodeInstanceEntryPoints.ts).</param>
+        /// <param name="commandLineArguments">Command-line arguments to be passed to the Node.js entry script (see HttpNodeInstanceEntryPoints.ts).</param>
+        /// <param name="environmentVars">Environment variables to be set on the Node.js process.</param>
+        /// <param name="launchWithDebugging">If true, passes a flag to the Node.js process telling it to accept V8 Inspector connections.</param>
+        /// <param name="debuggingPort">If debugging is enabled, the Node.js process should listen for V8 Inspector connections on this port.</param>
+        /// <returns></returns>
+        protected virtual ProcessStartInfo PrepareNodeProcessStartInfo(
+            string entryPointFilename, string projectPath, string commandLineArguments,
+            IDictionary<string, string> environmentVars, bool launchWithDebugging, int debuggingPort)
+        {
+            return PrepareNodeProcessStartInfo(entryPointFilename, projectPath, commandLineArguments, environmentVars, launchWithDebugging, debuggingPort);
+        }
+
+        /// <summary>
+        /// Configures a <see cref="ProcessStartInfo"/> instance describing how to launch the Node.js process.
+        /// </summary>
+        /// <param name="entryPointFilename">The entrypoint JavaScript file that the Node.js process should execute.</param>
+        /// <param name="projectPath">The root path of the project. This is used when locating Node.js modules relative to the project root.</param>
+        /// <param name="commandLineArguments">Command-line arguments to be passed to the Node.js entry script (see HttpNodeInstanceEntryPoints.ts).</param>
         /// <param name="environmentVars">Environment variables to be set on the Node.js process.</param>
         /// <param name="launchWithDebugging">If true, passes a flag to the Node.js process telling it to accept V8 Inspector connections.</param>
         /// <param name="debuggingPort">If debugging is enabled, the Node.js process should listen for V8 Inspector connections on this port.</param>
         /// <param name="nodeOptions">Command-line arguments to be passed to the Node.js process.</param>
         /// <returns></returns>
         protected virtual ProcessStartInfo PrepareNodeProcessStartInfo(
-            string entryPointFilename, string projectPath, string scriptArguments,
-            IDictionary<string, string> environmentVars, bool launchWithDebugging, int debuggingPort, string nodeOptions = null)
+            string entryPointFilename, string projectPath, string commandLineArguments,
+            IDictionary<string, string> environmentVars, bool launchWithDebugging, int debuggingPort, string nodeOptions)
         {
             // This method is virtual, as it provides a way to override the NODE_PATH or the path to node.exe
             string nodeDebuggingOptions;
@@ -234,7 +279,7 @@ namespace Microsoft.AspNetCore.NodeServices.HostingModels
             var startInfo = new ProcessStartInfo("node")
             {
                 // Syntactically consistent with the syntax specified in the Node.js documentation: "node [options] [V8 options] [script.js | -e "script" | -] [--] [arguments]" (see https://nodejs.org/api/cli.html#cli_synopsis).
-                Arguments = $"{nodeDebuggingOptions} {nodeOptions ?? string.Empty} \"{entryPointFilename}\" -- --parentPid {thisProcessPid} {scriptArguments ?? string.Empty}",
+                Arguments = $"{nodeDebuggingOptions} {nodeOptions ?? string.Empty} \"{entryPointFilename}\" -- --parentPid {thisProcessPid} {commandLineArguments ?? string.Empty}",
                 UseShellExecute = false,
                 RedirectStandardInput = true,
                 RedirectStandardOutput = true,


### PR DESCRIPTION
@SteveSandersonMS kindly consider.

Goal: 
Allow `INodeServices` consumers to specify Node.js Options such as `--inspect-brk`. The merits of exposing Node.js options were discussed in these issues:
- https://github.com/aspnet/JavaScriptServices/issues/796
- https://github.com/aspnet/JavaScriptServices/pull/804

Summary of changes:
I've made some changes that allow for node options to be specified. Backward compatibility has been preserved.
- Added `NodeServicesOptions.NodeOptions`.
- Added `nodeOptions` parameter to an overload of `OutOfProcessNodeInstance`'s constructor.
- Added `nodeOptions` parameter to an overload of `OutOfProcessNodeInstance.PrepareNodeProcessStartInfo`.
- Updated HttpNodeInstance and SocketNodeInstance (classes that implement OutOfProcessNodeInstance ) to pass `NodeServicesOptions.NodeOptions` to `OutOfProcessNodeInstances`'s constructor.

If these changes are acceptable, I'll update the ReadMe as well. Thanks for considering.