### PR TITLE
Updating aspnet-webpack-react to work with react-hot-loader v4

### DIFF
--- a/src/Microsoft.AspNetCore.SpaServices/npm/aspnet-webpack-react/package.json
+++ b/src/Microsoft.AspNetCore.SpaServices/npm/aspnet-webpack-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aspnet-webpack-react",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Helpers for using Webpack with React in ASP.NET Core projects. Works in conjunction with the Microsoft.AspNetCore.SpaServices NuGet package.",
   "main": "index.js",
   "scripts": {
@@ -17,12 +17,12 @@
     "url": "https://github.com/aspnet/JavaScriptServices.git"
   },
   "devDependencies": {
-    "@types/webpack": "^2.2.0",
+    "@types/webpack": "^4.4.0",
     "rimraf": "^2.5.4",
     "typescript": "^2.0.0",
-    "webpack": "^2.2.0"
+    "webpack": "^4.16.0"
   },
   "peerDependencies": {
-    "webpack": "^2.2.0 || ^3.0.0 || ^4.0.0"
+    "webpack": "^4.0.0"
   }
 }

--- a/src/Microsoft.AspNetCore.SpaServices/npm/aspnet-webpack-react/package.json
+++ b/src/Microsoft.AspNetCore.SpaServices/npm/aspnet-webpack-react/package.json
@@ -23,6 +23,6 @@
     "webpack": "^2.2.0"
   },
   "peerDependencies": {
-    "webpack": "^2.2.0"
+    "webpack": "^2.2.0 || ^3.0.0 || ^4.0.0"
   }
 }

--- a/src/Microsoft.AspNetCore.SpaServices/npm/aspnet-webpack-react/src/HotModuleReplacement.ts
+++ b/src/Microsoft.AspNetCore.SpaServices/npm/aspnet-webpack-react/src/HotModuleReplacement.ts
@@ -1,7 +1,5 @@
 import * as webpack from 'webpack';
 
-const reactHotLoaderWebpackLoader = 'react-hot-loader/webpack';
-const reactHotLoaderPatch = 'react-hot-loader/patch';
 const supportedTypeScriptLoaders = ['ts-loader', 'awesome-typescript-loader'];
 
 export function addReactHotModuleReplacementConfig(webpackConfig: webpack.Configuration) {
@@ -27,12 +25,6 @@ export function addReactHotModuleReplacementConfig(webpackConfig: webpack.Config
             continue;
         }
 
-        // This is the one - prefix it with the react-hot-loader loader
-        // (unless it's already in there somewhere)
-        if (!containsLoader(loadersArray, reactHotLoaderWebpackLoader)) {
-            loadersArray.unshift(reactHotLoaderWebpackLoader);
-            rule.use = loadersArray; // In case we normalised it to an array
-        }
         break;
     }
 
@@ -47,11 +39,6 @@ export function addReactHotModuleReplacementConfig(webpackConfig: webpack.Config
         if (typeof(entryConfig[entrypointName]) === 'string') {
             // Normalise to array
             entryConfig[entrypointName] = [entryConfig[entrypointName] as string];
-        }
-
-        let entryValueArray = entryConfig[entrypointName] as string[];
-        if (entryValueArray.indexOf(reactHotLoaderPatch) < 0) {
-            entryValueArray.unshift(reactHotLoaderPatch);
         }
     });
 }


### PR DESCRIPTION
This should solve the issue #1585 

- Deleting references to `react-hot-loader/webpack` and `react-hot-loader/patch` as it was removed in v4 of react-hot-loader. Referencing `react-hot-loader/babel`in webpack configuration is enough.
- Bumping peer dependency of webpack to 3 and 4