### PR TITLE
Add optional port parameter for the development servers

### DIFF
--- a/src/Microsoft.AspNetCore.SpaServices.Extensions/AngularCli/AngularCliMiddleware.cs
+++ b/src/Microsoft.AspNetCore.SpaServices.Extensions/AngularCli/AngularCliMiddleware.cs
@@ -23,7 +23,8 @@ namespace Microsoft.AspNetCore.SpaServices.AngularCli
 
         public static void Attach(
             ISpaBuilder spaBuilder,
-            string npmScriptName)
+            string npmScriptName,
+            int? spaPort)
         {
             var sourcePath = spaBuilder.Options.SourcePath;
             if (string.IsNullOrEmpty(sourcePath))
@@ -36,10 +37,25 @@ namespace Microsoft.AspNetCore.SpaServices.AngularCli
                 throw new ArgumentException("Cannot be null or empty", nameof(npmScriptName));
             }
 
-            // Start Angular CLI and attach to middleware pipeline
-            var appBuilder = spaBuilder.ApplicationBuilder;
-            var logger = LoggerFinder.GetOrCreateLogger(appBuilder, LogCategoryName);
-            var angularCliServerInfoTask = StartAngularCliServerAsync(sourcePath, npmScriptName, logger);
+            // We have to start the server by ourself if there wasn't any port specified
+            // or the specified port is still free (unused).
+            var shouldStartServer = !spaPort.HasValue || TcpPortFinder.TestPortAvailability(spaPort.Value);
+
+            Task<AngularCliServerInfo> angularCliServerInfoTask;
+            if (shouldStartServer)
+            {
+                // Start Angular CLI and attach to middleware pipeline
+                var appBuilder = spaBuilder.ApplicationBuilder;
+                var logger = LoggerFinder.GetOrCreateLogger(appBuilder, LogCategoryName);
+                angularCliServerInfoTask = StartAngularCliServerAsync(sourcePath, npmScriptName, logger);
+            }
+            else
+            {
+                angularCliServerInfoTask = Task.FromResult(new AngularCliServerInfo
+                {
+                    Port = spaPort.Value
+                });
+            }
 
             // Everything we proxy is hardcoded to target http://localhost because:
             // - the requests are always from the local machine (we're not accepting remote

--- a/src/Microsoft.AspNetCore.SpaServices.Extensions/AngularCli/AngularCliMiddlewareExtensions.cs
+++ b/src/Microsoft.AspNetCore.SpaServices.Extensions/AngularCli/AngularCliMiddlewareExtensions.cs
@@ -21,9 +21,11 @@ namespace Microsoft.AspNetCore.SpaServices.AngularCli
         /// </summary>
         /// <param name="spaBuilder">The <see cref="ISpaBuilder"/>.</param>
         /// <param name="npmScript">The name of the script in your package.json file that launches the Angular CLI process.</param>
+        /// <param name="spaPort">The port which the create-react-app server should listen to (optional).</param>
         public static void UseAngularCliServer(
             this ISpaBuilder spaBuilder,
-            string npmScript)
+            string npmScript,
+            int? spaPort = null)
         {
             if (spaBuilder == null)
             {
@@ -37,7 +39,7 @@ namespace Microsoft.AspNetCore.SpaServices.AngularCli
                 throw new InvalidOperationException($"To use {nameof(UseAngularCliServer)}, you must supply a non-empty value for the {nameof(SpaOptions.SourcePath)} property of {nameof(SpaOptions)} when calling {nameof(SpaApplicationBuilderExtensions.UseSpa)}.");
             }
 
-            AngularCliMiddleware.Attach(spaBuilder, npmScript);
+            AngularCliMiddleware.Attach(spaBuilder, npmScript, spaPort);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.SpaServices.Extensions/ReactDevelopmentServer/ReactDevelopmentServerMiddleware.cs
+++ b/src/Microsoft.AspNetCore.SpaServices.Extensions/ReactDevelopmentServer/ReactDevelopmentServerMiddleware.cs
@@ -22,7 +22,8 @@ namespace Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer
 
         public static void Attach(
             ISpaBuilder spaBuilder,
-            string npmScriptName)
+            string npmScriptName,
+            int? spaPort)
         {
             var sourcePath = spaBuilder.Options.SourcePath;
             if (string.IsNullOrEmpty(sourcePath))
@@ -35,10 +36,22 @@ namespace Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer
                 throw new ArgumentException("Cannot be null or empty", nameof(npmScriptName));
             }
 
-            // Start create-react-app and attach to middleware pipeline
-            var appBuilder = spaBuilder.ApplicationBuilder;
-            var logger = LoggerFinder.GetOrCreateLogger(appBuilder, LogCategoryName);
-            var portTask = StartCreateReactAppServerAsync(sourcePath, npmScriptName, logger);
+            // We have to start the server by ourself if there wasn't any port specified
+            // or the specified port is still free (unused).
+            var shouldStartServer = !spaPort.HasValue || TcpPortFinder.TestPortAvailability(spaPort.Value);
+
+            Task<int> portTask;
+            if (shouldStartServer)
+            {
+                // Start create-react-app and attach to middleware pipeline
+                var appBuilder = spaBuilder.ApplicationBuilder;
+                var logger = LoggerFinder.GetOrCreateLogger(appBuilder, LogCategoryName);
+                portTask = StartCreateReactAppServerAsync(sourcePath, npmScriptName, logger);
+            }
+            else
+            {
+                portTask = Task.FromResult(spaPort.Value);
+            }
 
             // Everything we proxy is hardcoded to target http://localhost because:
             // - the requests are always from the local machine (we're not accepting remote

--- a/src/Microsoft.AspNetCore.SpaServices.Extensions/ReactDevelopmentServer/ReactDevelopmentServerMiddlewareExtensions.cs
+++ b/src/Microsoft.AspNetCore.SpaServices.Extensions/ReactDevelopmentServer/ReactDevelopmentServerMiddlewareExtensions.cs
@@ -21,9 +21,11 @@ namespace Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer
         /// </summary>
         /// <param name="spaBuilder">The <see cref="ISpaBuilder"/>.</param>
         /// <param name="npmScript">The name of the script in your package.json file that launches the create-react-app server.</param>
+        /// <param name="spaPort">The port which the create-react-app server should listen to (optional).</param>
         public static void UseReactDevelopmentServer(
             this ISpaBuilder spaBuilder,
-            string npmScript)
+            string npmScript,
+            int? spaPort = null)
         {
             if (spaBuilder == null)
             {
@@ -37,7 +39,7 @@ namespace Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer
                 throw new InvalidOperationException($"To use {nameof(UseReactDevelopmentServer)}, you must supply a non-empty value for the {nameof(SpaOptions.SourcePath)} property of {nameof(SpaOptions)} when calling {nameof(SpaApplicationBuilderExtensions.UseSpa)}.");
             }
 
-            ReactDevelopmentServerMiddleware.Attach(spaBuilder, npmScript);
+            ReactDevelopmentServerMiddleware.Attach(spaBuilder, npmScript, spaPort);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.SpaServices.Extensions/Util/TcpPortFinder.cs
+++ b/src/Microsoft.AspNetCore.SpaServices.Extensions/Util/TcpPortFinder.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Net;
+using System.Net.NetworkInformation;
 using System.Net.Sockets;
 
 namespace Microsoft.AspNetCore.SpaServices.Util
@@ -20,6 +21,20 @@ namespace Microsoft.AspNetCore.SpaServices.Util
             {
                 listener.Stop();
             }
+        }
+
+        public static bool TestPortAvailability(int port)
+        {
+            var ipProperties = IPGlobalProperties.GetIPGlobalProperties();
+            var ipEndPoints = ipProperties.GetActiveTcpListeners();
+            foreach (var endPoint in ipEndPoints)
+            {
+                if (endPoint.Port == port)
+                {
+                    return false;
+                }
+            }
+            return true;
         }
     }
 }


### PR DESCRIPTION
As written in #1766 I would find it useful to have the ability to specify a port in `UseReactDevelopmentServer` and `UseAngularCliServer`. With that JavaScriptServices would automatically detect if there is already an active development server running and start a new one otherwise.