### PR TITLE
Add optional PackageManagerName Option to use alternative Package Managers like Yarn

### DIFF
--- a/src/Microsoft.AspNetCore.SpaServices.Extensions/AngularCli/AngularCliBuilder.cs
+++ b/src/Microsoft.AspNetCore.SpaServices.Extensions/AngularCli/AngularCliBuilder.cs
@@ -41,6 +41,7 @@ namespace Microsoft.AspNetCore.SpaServices.AngularCli
         public async Task Build(ISpaBuilder spaBuilder)
         {
             var sourcePath = spaBuilder.Options.SourcePath;
+            var pkgManagerName = spaBuilder.Options.PackageManagerName;
             if (string.IsNullOrEmpty(sourcePath))
             {
                 throw new InvalidOperationException($"To use {nameof(AngularCliBuilder)}, you must supply a non-empty value for the {nameof(SpaOptions.SourcePath)} property of {nameof(SpaOptions)} when calling {nameof(SpaApplicationBuilderExtensions.UseSpa)}.");
@@ -51,6 +52,7 @@ namespace Microsoft.AspNetCore.SpaServices.AngularCli
                 nameof(AngularCliBuilder));
             var npmScriptRunner = new NpmScriptRunner(
                 sourcePath,
+                pkgManagerName,
                 _npmScriptName,
                 "--watch",
                 null);

--- a/src/Microsoft.AspNetCore.SpaServices.Extensions/AngularCli/AngularCliMiddleware.cs
+++ b/src/Microsoft.AspNetCore.SpaServices.Extensions/AngularCli/AngularCliMiddleware.cs
@@ -26,6 +26,7 @@ namespace Microsoft.AspNetCore.SpaServices.AngularCli
             string npmScriptName)
         {
             var sourcePath = spaBuilder.Options.SourcePath;
+            var pkgManagerName = spaBuilder.Options.PackageManagerName;
             if (string.IsNullOrEmpty(sourcePath))
             {
                 throw new ArgumentException("Cannot be null or empty", nameof(sourcePath));
@@ -39,7 +40,7 @@ namespace Microsoft.AspNetCore.SpaServices.AngularCli
             // Start Angular CLI and attach to middleware pipeline
             var appBuilder = spaBuilder.ApplicationBuilder;
             var logger = LoggerFinder.GetOrCreateLogger(appBuilder, LogCategoryName);
-            var angularCliServerInfoTask = StartAngularCliServerAsync(sourcePath, npmScriptName, logger);
+            var angularCliServerInfoTask = StartAngularCliServerAsync(sourcePath, pkgManagerName, npmScriptName, logger);
 
             // Everything we proxy is hardcoded to target http://localhost because:
             // - the requests are always from the local machine (we're not accepting remote
@@ -62,13 +63,13 @@ namespace Microsoft.AspNetCore.SpaServices.AngularCli
         }
 
         private static async Task<AngularCliServerInfo> StartAngularCliServerAsync(
-            string sourcePath, string npmScriptName, ILogger logger)
+            string sourcePath, string pkgManagerName, string npmScriptName, ILogger logger)
         {
             var portNumber = TcpPortFinder.FindAvailablePort();
             logger.LogInformation($"Starting @angular/cli on port {portNumber}...");
 
             var npmScriptRunner = new NpmScriptRunner(
-                sourcePath, npmScriptName, $"--port {portNumber}", null);
+                sourcePath, pkgManagerName, npmScriptName, $"--port {portNumber}", null);
             npmScriptRunner.AttachToLogger(logger);
 
             Match openBrowserLine;

--- a/src/Microsoft.AspNetCore.SpaServices.Extensions/ReactDevelopmentServer/ReactDevelopmentServerMiddleware.cs
+++ b/src/Microsoft.AspNetCore.SpaServices.Extensions/ReactDevelopmentServer/ReactDevelopmentServerMiddleware.cs
@@ -25,9 +25,15 @@ namespace Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer
             string npmScriptName)
         {
             var sourcePath = spaBuilder.Options.SourcePath;
+            var pkgManagerName = spaBuilder.Options.PackageManagerName;
             if (string.IsNullOrEmpty(sourcePath))
             {
                 throw new ArgumentException("Cannot be null or empty", nameof(sourcePath));
+            }
+
+            if (string.IsNullOrEmpty(sourcePath))
+            {
+                throw new ArgumentException("Cannot be null or empty", nameof(pkgManagerName));
             }
 
             if (string.IsNullOrEmpty(npmScriptName))
@@ -38,7 +44,7 @@ namespace Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer
             // Start create-react-app and attach to middleware pipeline
             var appBuilder = spaBuilder.ApplicationBuilder;
             var logger = LoggerFinder.GetOrCreateLogger(appBuilder, LogCategoryName);
-            var portTask = StartCreateReactAppServerAsync(sourcePath, npmScriptName, logger);
+            var portTask = StartCreateReactAppServerAsync(sourcePath, pkgManagerName, npmScriptName, logger);
 
             // Everything we proxy is hardcoded to target http://localhost because:
             // - the requests are always from the local machine (we're not accepting remote
@@ -61,7 +67,7 @@ namespace Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer
         }
 
         private static async Task<int> StartCreateReactAppServerAsync(
-            string sourcePath, string npmScriptName, ILogger logger)
+            string sourcePath, string pkgManagerName, string npmScriptName, ILogger logger)
         {
             var portNumber = TcpPortFinder.FindAvailablePort();
             logger.LogInformation($"Starting create-react-app server on port {portNumber}...");
@@ -72,7 +78,7 @@ namespace Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer
                 { "BROWSER", "none" }, // We don't want create-react-app to open its own extra browser window pointing to the internal dev server port
             };
             var npmScriptRunner = new NpmScriptRunner(
-                sourcePath, npmScriptName, null, envVars);
+                sourcePath, pkgManagerName, npmScriptName, null, envVars);
             npmScriptRunner.AttachToLogger(logger);
 
             using (var stdErrReader = new EventedStreamStringReader(npmScriptRunner.StdErr))

--- a/src/Microsoft.AspNetCore.SpaServices.Extensions/ReactDevelopmentServer/ReactDevelopmentServerMiddlewareExtensions.cs
+++ b/src/Microsoft.AspNetCore.SpaServices.Extensions/ReactDevelopmentServer/ReactDevelopmentServerMiddlewareExtensions.cs
@@ -37,6 +37,11 @@ namespace Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer
                 throw new InvalidOperationException($"To use {nameof(UseReactDevelopmentServer)}, you must supply a non-empty value for the {nameof(SpaOptions.SourcePath)} property of {nameof(SpaOptions)} when calling {nameof(SpaApplicationBuilderExtensions.UseSpa)}.");
             }
 
+            if (string.IsNullOrEmpty(spaOptions.PackageManagerName))
+            {
+                throw new InvalidOperationException($"To use {nameof(UseReactDevelopmentServer)}, you must supply a non-empty value for the {nameof(SpaOptions.PackageManagerName)} property of {nameof(SpaOptions)} when calling {nameof(SpaApplicationBuilderExtensions.UseSpa)}.");
+            }
+
             ReactDevelopmentServerMiddleware.Attach(spaBuilder, npmScript);
         }
     }

--- a/src/Microsoft.AspNetCore.SpaServices.Extensions/SpaOptions.cs
+++ b/src/Microsoft.AspNetCore.SpaServices.Extensions/SpaOptions.cs
@@ -15,6 +15,7 @@ namespace Microsoft.AspNetCore.SpaServices
     public class SpaOptions
     {
         private PathString _defaultPage = "/index.html";
+        private static string _defaultPackageManagerName = "npm";
 
         /// <summary>
         /// Constructs a new instance of <see cref="SpaOptions"/>.
@@ -32,6 +33,7 @@ namespace Microsoft.AspNetCore.SpaServices
             _defaultPage = copyFromOptions.DefaultPage;
             DefaultPageStaticFileOptions = copyFromOptions.DefaultPageStaticFileOptions;
             SourcePath = copyFromOptions.SourcePath;
+            _defaultPackageManagerName = copyFromOptions.PackageManagerName;
         }
 
         /// <summary>
@@ -68,6 +70,15 @@ namespace Microsoft.AspNetCore.SpaServices
         /// development. The directory may not exist in published applications.
         /// </summary>
         public string SourcePath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the package manager executible, (e.g npm,
+        /// yarn) to run the SPA.
+        /// 
+        /// If not set, npm will be assumed as the default package manager 
+        /// executable
+        /// </summary>
+        public string PackageManagerName { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum duration that a request will wait for the SPA


### PR DESCRIPTION
While the issue in #1760 can mostly be addressed by changing the package install scripts in the .csproj to use yarn instead of npm to install packages, SpaService will still use npm as the package manager of choice when executing `npmScripts` (i.e `start`)

While cross-play between yarn and npm has got a lot more stable, mixing use of npm and yarn can still lead to undesired side-effects and problems. Some users may also want to use Yarn specific features, not available in npm.

Yarn shares the same `run-scripts` cli api as npm thanks to its' shorter "run" alias, so all that's left to do is to specify that the user wants to use `yarn` to perform the command instead of `npm`.

This PR introduces an optional `PackageManagerName` Option to `SPABuilder` which allows the user to define the name of the package manager executable they wish to use at runtime.

This doesn't change the requirement that the executable be available in the system's PATH as is the case with npm, but if gives the user the flexibility to define which package manager they wish to use. In combination with editing the package install commands created in the spa-templates, users can now yarn, or another alternative package manager to npm.

In the absense of a specific option, the spaBuilder will continue to default to `npm`   

A future improvement may be to also allow the user to define their own "run-scripts-alias" part, in the possible event a new killer javascript package manager comes along that has a different label for the `run-script` behaviour (e.g "r")
