### PR TITLE
Remove obsolete API usage

### DIFF
--- a/src/Microsoft.AspNetCore.NodeServices/Configuration/NodeServicesOptions.cs
+++ b/src/Microsoft.AspNetCore.NodeServices/Configuration/NodeServicesOptions.cs
@@ -58,8 +58,9 @@ namespace Microsoft.AspNetCore.NodeServices
             var loggerFactory = serviceProvider.GetService<ILoggerFactory>();
             NodeInstanceOutputLogger = loggerFactory != null
                 ? loggerFactory.CreateLogger(LogCategoryName)
+#pragma warning disable CS0618 // Type or member is obsolete
                 : new ConsoleLogger(LogCategoryName, null, false);
-
+#pragma warning restore CS0618
             // By default, we use this package's built-in out-of-process-via-HTTP hosting/transport
             this.UseHttpHosting();
         }

--- a/src/Microsoft.AspNetCore.SpaServices.Extensions/Util/LoggerFinder.cs
+++ b/src/Microsoft.AspNetCore.SpaServices.Extensions/Util/LoggerFinder.cs
@@ -18,7 +18,9 @@ namespace Microsoft.AspNetCore.SpaServices.Util
             var loggerFactory = appBuilder.ApplicationServices.GetService<ILoggerFactory>();
             var logger = loggerFactory != null
                 ? loggerFactory.CreateLogger(logCategoryName)
+#pragma warning disable CS0618 // Type or member is obsolete
                 : new ConsoleLogger(logCategoryName, null, false);
+#pragma warning restore CS0618
             return logger;
         }
     }


### PR DESCRIPTION
Using this type for 2.2 is fine I'll make a full fix in 3.0.