### PR TITLE
Do not fallback to creating console logger

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -16,6 +16,7 @@
     <MicrosoftAspNetCoreWebSocketsPackageVersion>3.0.0-alpha1-10670</MicrosoftAspNetCoreWebSocketsPackageVersion>
     <MicrosoftExtensionsDependencyInjectionPackageVersion>3.0.0-alpha1-10670</MicrosoftExtensionsDependencyInjectionPackageVersion>
     <MicrosoftExtensionsFileProvidersPhysicalPackageVersion>3.0.0-alpha1-10670</MicrosoftExtensionsFileProvidersPhysicalPackageVersion>
+    <MicrosoftExtensionsLoggingAbstractionsPackageVersion>3.0.0-alpha1-10670</MicrosoftExtensionsLoggingAbstractionsPackageVersion>
     <MicrosoftExtensionsLoggingConsolePackageVersion>3.0.0-alpha1-10670</MicrosoftExtensionsLoggingConsolePackageVersion>
     <MicrosoftExtensionsLoggingDebugPackageVersion>3.0.0-alpha1-10670</MicrosoftExtensionsLoggingDebugPackageVersion>
     <MicrosoftNETCoreApp20PackageVersion>2.0.9</MicrosoftNETCoreApp20PackageVersion>

--- a/samples/misc/LatencyTest/LatencyTest.csproj
+++ b/samples/misc/LatencyTest/LatencyTest.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(MicrosoftExtensionsDependencyInjectionPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsolePackageVersion)" />
   </ItemGroup>
 
 </Project>

--- a/samples/misc/NodeServicesExamples/NodeServicesExamples.csproj
+++ b/samples/misc/NodeServicesExamples/NodeServicesExamples.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="$(MicrosoftAspNetCoreServerKestrelPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(MicrosoftAspNetCoreStaticFilesPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(MicrosoftExtensionsLoggingDebugPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsolePackageVersion)" />
     <PackageReference Include="Microsoft.NET.Sdk.Razor" Version="$(MicrosoftNETSdkRazorPackageVersion)" PrivateAssets="All" />
   </ItemGroup>
 

--- a/samples/misc/Webpack/Webpack.csproj
+++ b/samples/misc/Webpack/Webpack.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="$(MicrosoftAspNetCoreServerKestrelPackageVersion)" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="$(MicrosoftAspNetCoreStaticFilesPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(MicrosoftExtensionsLoggingDebugPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsolePackageVersion)" />
     <PackageReference Include="Microsoft.NET.Sdk.Razor" Version="$(MicrosoftNETSdkRazorPackageVersion)" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/Microsoft.AspNetCore.NodeServices/Configuration/NodeServicesOptions.cs
+++ b/src/Microsoft.AspNetCore.NodeServices/Configuration/NodeServicesOptions.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.NodeServices.HostingModels;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Logging.Console;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Microsoft.AspNetCore.NodeServices
 {
@@ -58,9 +58,7 @@ namespace Microsoft.AspNetCore.NodeServices
             var loggerFactory = serviceProvider.GetService<ILoggerFactory>();
             NodeInstanceOutputLogger = loggerFactory != null
                 ? loggerFactory.CreateLogger(LogCategoryName)
-#pragma warning disable CS0618 // Type or member is obsolete
-                : new ConsoleLogger(LogCategoryName, null, false);
-#pragma warning restore CS0618
+                : NullLogger.Instance;
             // By default, we use this package's built-in out-of-process-via-HTTP hosting/transport
             this.UseHttpHosting();
         }

--- a/src/Microsoft.AspNetCore.NodeServices/Microsoft.AspNetCore.NodeServices.csproj
+++ b/src/Microsoft.AspNetCore.NodeServices/Microsoft.AspNetCore.NodeServices.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="$(MicrosoftAspNetCoreHostingAbstractionsPackageVersion)" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsolePackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(MicrosoftExtensionsLoggingAbstractionsPackageVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
   </ItemGroup>
 

--- a/src/Microsoft.AspNetCore.SpaServices.Extensions/Util/LoggerFinder.cs
+++ b/src/Microsoft.AspNetCore.SpaServices.Extensions/Util/LoggerFinder.cs
@@ -4,7 +4,7 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Console;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Microsoft.AspNetCore.SpaServices.Util
 {
@@ -14,13 +14,11 @@ namespace Microsoft.AspNetCore.SpaServices.Util
             IApplicationBuilder appBuilder,
             string logCategoryName)
         {
-            // If the DI system gives us a logger, use it. Otherwise, set up a default one.
+            // If the DI system gives us a logger, use it. Otherwise, set up a default one
             var loggerFactory = appBuilder.ApplicationServices.GetService<ILoggerFactory>();
             var logger = loggerFactory != null
                 ? loggerFactory.CreateLogger(logCategoryName)
-#pragma warning disable CS0618 // Type or member is obsolete
-                : new ConsoleLogger(logCategoryName, null, false);
-#pragma warning restore CS0618
+                : NullLogger.Instance;
             return logger;
         }
     }


### PR DESCRIPTION
Falling back to creating instances of console logger is bad practice. Each of them would create a new writing thread and background queue. In addition, ConsoleLogger type is becoming private.

cc @Eilon

Technically it's a breaking change for customers who didn't have logging configured at all and used JavaScriptServices.